### PR TITLE
refactor: TestMemberController가 TestMemberService만 의존하도록 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
@@ -19,8 +19,6 @@ import org.springframework.web.bind.annotation.*;
 public class TestMemberController {
 
     private final TestMemberService testMemberService;
-    private final OnboardingMemberService onboardingMemberService;
-    private final AdminMemberService adminMemberService;
 
     @Operation(summary = "게스트 회원 생성", description = "테스트용 API입니다. 깃허브 핸들명을 입력받아 임시 회원을 생성합니다.")
     @PostMapping
@@ -33,14 +31,14 @@ public class TestMemberController {
     @PostMapping("/token/github-handle")
     public ResponseEntity<MemberTokenResponse> createTemporaryTokenByGithubHandle(
             @Valid @RequestBody MemberTokenByGithubHandleRequest request) {
-        var response = onboardingMemberService.createTemporaryTokenByGithubHandle(request);
+        var response = testMemberService.createTemporaryTokenByGithubHandle(request);
         return ResponseEntity.ok().body(response);
     }
 
     @Operation(summary = "게스트로 강등", description = "테스트용 API입니다. 현재 멤버 역할을 게스트로 강등시키기 위해 사용합니다.")
     @PatchMapping("/demotion")
     public ResponseEntity<Void> demoteToGuest() {
-        adminMemberService.demoteToGuestAndRegularRequirementToUnsatisfied();
+        testMemberService.demoteToGuestAndRegularRequirementToUnsatisfied();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
@@ -1,10 +1,11 @@
 package com.gdschongik.gdsc.domain.member.api;
 
-import com.gdschongik.gdsc.domain.member.application.AdminMemberService;
-import com.gdschongik.gdsc.domain.member.application.OnboardingMemberService;
+import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.*;
+
 import com.gdschongik.gdsc.domain.member.application.TestMemberService;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByGithubHandleRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberTokenResponse;
+import com.gdschongik.gdsc.global.annotation.ConditionalOnProfile;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/test/members")
 @RequiredArgsConstructor
+@ConditionalOnProfile({LOCAL, DEV})
 public class TestMemberController {
 
     private final TestMemberService testMemberService;

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -10,15 +10,12 @@ import com.gdschongik.gdsc.domain.member.dto.request.MemberDemoteRequest;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberQueryOption;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberUpdateRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.AdminMemberResponse;
-import com.gdschongik.gdsc.domain.membership.application.MembershipService;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
 import com.gdschongik.gdsc.global.exception.CustomException;
-import com.gdschongik.gdsc.global.util.EnvironmentUtil;
 import com.gdschongik.gdsc.global.util.ExcelUtil;
-import com.gdschongik.gdsc.global.util.MemberUtil;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -39,9 +36,6 @@ public class AdminMemberService {
     private final RecruitmentRepository recruitmentRepository;
     private final RecruitmentRoundRepository recruitmentRoundRepository;
     private final MemberValidator memberValidator;
-    private final MemberUtil memberUtil;
-    private final EnvironmentUtil environmentUtil;
-    private final MembershipService membershipService;
 
     public Page<AdminMemberResponse> searchMembers(MemberQueryOption queryOption, Pageable pageable) {
         Page<Member> members = memberRepository.searchMembers(queryOption, pageable);
@@ -91,17 +85,6 @@ public class AdminMemberService {
     }
 
     @Transactional
-    public void demoteToGuestAndRegularRequirementToUnsatisfied() {
-        validateProfile();
-        Member member = memberUtil.getCurrentMember();
-        member.demoteToGuest();
-
-        membershipService.deleteMembership(member);
-
-        log.info("[AdminMemberService] 게스트로 강등: demotedMemberId={}", member.getId());
-    }
-
-    @Transactional
     public void advanceAllAdvanceFailedMembersToRegular(String discordUsername) {
         Member currentMember = memberRepository
                 .findByDiscordUsername(discordUsername)
@@ -138,11 +121,5 @@ public class AdminMemberService {
         memberRepository.save(memberToAssign);
 
         log.info("[AdminMemberService] 어드민 권한 부여: memberId={}", memberToAssign.getId());
-    }
-
-    private void validateProfile() {
-        if (!environmentUtil.isDevAndLocalProfile()) {
-            throw new CustomException(FORBIDDEN_ACCESS);
-        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
@@ -2,9 +2,17 @@ package com.gdschongik.gdsc.domain.member.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.auth.application.JwtService;
+import com.gdschongik.gdsc.domain.auth.dto.AccessTokenDto;
+import com.gdschongik.gdsc.domain.auth.dto.RefreshTokenDto;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByGithubHandleRequest;
+import com.gdschongik.gdsc.domain.member.dto.response.MemberTokenResponse;
+import com.gdschongik.gdsc.domain.membership.application.MembershipService;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.global.security.MemberAuthInfo;
+import com.gdschongik.gdsc.global.util.MemberUtil;
 import com.gdschongik.gdsc.infra.github.client.GithubClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,8 +24,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TestMemberService {
 
+    private final MembershipService membershipService;
+    private final JwtService jwtService;
     private final MemberRepository memberRepository;
     private final GithubClient githubClient;
+    private final MemberUtil memberUtil;
 
     @Transactional
     public void createTestMember(String githubHandle) {
@@ -29,5 +40,27 @@ public class TestMemberService {
 
         Member guestMember = Member.createGuest(githubOauthId);
         memberRepository.save(guestMember);
+    }
+
+    public MemberTokenResponse createTemporaryTokenByGithubHandle(MemberTokenByGithubHandleRequest request) {
+        final String oauthId = githubClient.getOauthId(request.githubHandle());
+
+        final Member member =
+                memberRepository.findByOauthId(oauthId).orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        AccessTokenDto accessTokenDto = jwtService.createAccessToken(MemberAuthInfo.from(member));
+        RefreshTokenDto refreshTokenDto = jwtService.createRefreshToken(member.getId());
+
+        return new MemberTokenResponse(accessTokenDto.tokenValue(), refreshTokenDto.tokenValue());
+    }
+
+    @Transactional
+    public void demoteToGuestAndRegularRequirementToUnsatisfied() {
+        Member member = memberUtil.getCurrentMember();
+        member.demoteToGuest();
+
+        membershipService.deleteMembership(member);
+
+        log.info("[AdminMemberService] 게스트로 강등: demotedMemberId={}", member.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
@@ -64,6 +64,6 @@ public class TestMemberService {
 
         membershipService.deleteMembership(member);
 
-        log.info("[AdminMemberService] 게스트로 강등: demotedMemberId={}", member.getId());
+        log.info("[TestMemberService] 게스트로 강등: demotedMemberId={}", member.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/TestMemberService.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.member.application;
 
+import static com.gdschongik.gdsc.global.common.constant.EnvironmentConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.auth.application.JwtService;
@@ -10,6 +11,7 @@ import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.dto.request.MemberTokenByGithubHandleRequest;
 import com.gdschongik.gdsc.domain.member.dto.response.MemberTokenResponse;
 import com.gdschongik.gdsc.domain.membership.application.MembershipService;
+import com.gdschongik.gdsc.global.annotation.ConditionalOnProfile;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.security.MemberAuthInfo;
 import com.gdschongik.gdsc.global.util.MemberUtil;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@ConditionalOnProfile({LOCAL, DEV})
 public class TestMemberService {
 
     private final MembershipService membershipService;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1058

## 📌 작업 내용 및 특이사항
- 테스트용 멤버 관련 API 로직들이 `AdminMemberService`, `OnboardingMemberService`에 분산되어 있어 `TestMemberService`로 모아 관리하도록 변경했습니다.
- 각각의 서비스에서 `validateProfile()`을 통해 prod 환경에서의 호출을 막고 있던 테스트용 메서드들을 `ConditionalOnProfile`을 사용해 DEV, LOCAL 환경에서만 빈이 생성되도록 변경했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 테스트 환경(LOCAL, DEV)에서 임시 토큰 생성 및 멤버 강등 기능이 테스트 멤버 서비스로 통합되었습니다.

- **버그 수정**
    - 기존 온보딩 및 관리자 서비스에서 제공하던 임시 토큰 발급 및 멤버 강등 기능이 테스트 멤버 서비스로 이전되어, 테스트 환경에서만 동작하도록 개선되었습니다.

- **리팩터링**
    - 테스트 환경에서만 활성화되는 컨트롤러 및 서비스 구조로 변경되어, 코드가 더욱 단순화되고 유지보수가 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->