### PR TITLE
CODEOWNERS 조직명만 소문자로 변경

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @GDSC-Hongik/backend-dev
+* @gdg-hongik-univ/backend-dev


### PR DESCRIPTION
## 🌱 관련 이슈
- 

## 📌 작업 내용 및 특이사항
- CODEOWNERS의 organization 이름을 소문자(@gdg-hongik-univ)로 변경했습니다.

## 📝 참고사항
- 

## 📚 기타
- 
