### PR TITLE
feat: 스터디 별로 WIL 글자수 제한을 지정하도록 개선

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/AdminStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/AdminStudyServiceV2.java
@@ -47,7 +47,8 @@ public class AdminStudyServiceV2 {
                 request.discordChannelId(),
                 request.discordRoleId(),
                 mentor,
-                attendanceNumberGenerator);
+                attendanceNumberGenerator,
+                request.minAssignmentContentLength());
 
         memberRepository.save(mentor);
         studyV2Repository.save(study);

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/AdminStudyServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/AdminStudyServiceV2.java
@@ -48,7 +48,7 @@ public class AdminStudyServiceV2 {
                 request.discordRoleId(),
                 mentor,
                 attendanceNumberGenerator,
-                request.minAssignmentContentLength());
+                request.minAssignmentLength());
 
         memberRepository.save(mentor);
         studyV2Repository.save(study);

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentAssignmentHistoryServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentAssignmentHistoryServiceV2.java
@@ -57,7 +57,7 @@ public class StudentAssignmentHistoryServiceV2 {
                 githubClient.getLatestAssignmentSubmissionFetcher(repositoryLink, studySession.getPosition());
         AssignmentHistoryV2 assignmentHistory = findOrCreate(currentMember, studySession);
 
-        assignmentHistoryGraderV2.judge(fetcher, assignmentHistory);
+        assignmentHistoryGraderV2.judge(fetcher, assignmentHistory, study.getMinAssignmentContentLength());
 
         assignmentHistoryV2Repository.save(assignmentHistory);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentAssignmentHistoryServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentAssignmentHistoryServiceV2.java
@@ -57,7 +57,7 @@ public class StudentAssignmentHistoryServiceV2 {
                 githubClient.getLatestAssignmentSubmissionFetcher(repositoryLink, studySession.getPosition());
         AssignmentHistoryV2 assignmentHistory = findOrCreate(currentMember, studySession);
 
-        assignmentHistoryGraderV2.judge(fetcher, assignmentHistory, study.getMinAssignmentContentLength());
+        assignmentHistoryGraderV2.judge(fetcher, assignmentHistory, study.getMinAssignmentLength());
 
         assignmentHistoryV2Repository.save(assignmentHistory);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyFactory.java
@@ -28,7 +28,8 @@ public class StudyFactory {
             String discordChannelId,
             String discordRoleId,
             Member mentor,
-            AttendanceNumberGenerator attendanceNumberGenerator) {
+            AttendanceNumberGenerator attendanceNumberGenerator,
+            Integer minAssignmentContentCount) {
         if (type.isLive()) {
             return createLive(
                     type,
@@ -42,10 +43,18 @@ public class StudyFactory {
                     discordChannelId,
                     discordRoleId,
                     mentor,
-                    attendanceNumberGenerator);
+                    attendanceNumberGenerator,
+                    minAssignmentContentCount);
         } else {
             return createAssignment(
-                    title, semester, totalRound, applicationPeriod, discordChannelId, discordRoleId, mentor);
+                    title,
+                    semester,
+                    totalRound,
+                    applicationPeriod,
+                    discordChannelId,
+                    discordRoleId,
+                    mentor,
+                    minAssignmentContentCount);
         }
     }
 
@@ -61,7 +70,8 @@ public class StudyFactory {
             String discordChannelId,
             String discordRoleId,
             Member mentor,
-            AttendanceNumberGenerator attendanceNumberGenerator) {
+            AttendanceNumberGenerator attendanceNumberGenerator,
+            Integer minAssignmentContentCount) {
         StudyV2 study = StudyV2.createLive(
                 type,
                 title,
@@ -73,7 +83,8 @@ public class StudyFactory {
                 applicationPeriod,
                 discordChannelId,
                 discordRoleId,
-                mentor);
+                mentor,
+                minAssignmentContentCount);
 
         IntStream.rangeClosed(1, totalRound)
                 .forEach(
@@ -89,9 +100,17 @@ public class StudyFactory {
             Period applicationPeriod,
             String discordChannelId,
             String discordRoleId,
-            Member mentor) {
+            Member mentor,
+            Integer minAssignmentContentCount) {
         StudyV2 study = StudyV2.createAssignment(
-                title, semester, totalRound, applicationPeriod, discordChannelId, discordRoleId, mentor);
+                title,
+                semester,
+                totalRound,
+                applicationPeriod,
+                discordChannelId,
+                discordRoleId,
+                mentor,
+                minAssignmentContentCount);
 
         IntStream.rangeClosed(1, totalRound).forEach(round -> StudySessionV2.createEmptyForAssignment(round, study));
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyFactory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyFactory.java
@@ -29,7 +29,7 @@ public class StudyFactory {
             String discordRoleId,
             Member mentor,
             AttendanceNumberGenerator attendanceNumberGenerator,
-            Integer minAssignmentContentCount) {
+            Integer minAssignmentLength) {
         if (type.isLive()) {
             return createLive(
                     type,
@@ -44,7 +44,7 @@ public class StudyFactory {
                     discordRoleId,
                     mentor,
                     attendanceNumberGenerator,
-                    minAssignmentContentCount);
+                    minAssignmentLength);
         } else {
             return createAssignment(
                     title,
@@ -54,7 +54,7 @@ public class StudyFactory {
                     discordChannelId,
                     discordRoleId,
                     mentor,
-                    minAssignmentContentCount);
+                    minAssignmentLength);
         }
     }
 
@@ -71,7 +71,7 @@ public class StudyFactory {
             String discordRoleId,
             Member mentor,
             AttendanceNumberGenerator attendanceNumberGenerator,
-            Integer minAssignmentContentCount) {
+            Integer minAssignmentLength) {
         StudyV2 study = StudyV2.createLive(
                 type,
                 title,
@@ -84,7 +84,7 @@ public class StudyFactory {
                 discordChannelId,
                 discordRoleId,
                 mentor,
-                minAssignmentContentCount);
+                minAssignmentLength);
 
         IntStream.rangeClosed(1, totalRound)
                 .forEach(
@@ -101,7 +101,7 @@ public class StudyFactory {
             String discordChannelId,
             String discordRoleId,
             Member mentor,
-            Integer minAssignmentContentCount) {
+            Integer minAssignmentLength) {
         StudyV2 study = StudyV2.createAssignment(
                 title,
                 semester,
@@ -110,7 +110,7 @@ public class StudyFactory {
                 discordChannelId,
                 discordRoleId,
                 mentor,
-                minAssignmentContentCount);
+                minAssignmentLength);
 
         IntStream.rangeClosed(1, totalRound).forEach(round -> StudySessionV2.createEmptyForAssignment(round, study));
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyUpdateCommand.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyUpdateCommand.java
@@ -13,7 +13,7 @@ public record StudyUpdateCommand(
         DayOfWeek dayOfWeek,
         LocalTime startTime,
         LocalTime endTime,
-        Integer minAssignmentContentLength,
+        Integer minAssignmentLength,
         List<Session> studySessions) {
 
     public record Session(

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyUpdateCommand.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyUpdateCommand.java
@@ -13,6 +13,7 @@ public record StudyUpdateCommand(
         DayOfWeek dayOfWeek,
         LocalTime startTime,
         LocalTime endTime,
+        Integer minAssignmentContentLength,
         List<Session> studySessions) {
 
     public record Session(

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -151,7 +151,8 @@ public class StudyV2 extends BaseEntity {
             Period applicationPeriod,
             String discordChannelId,
             String discordRoleId,
-            Member mentor) {
+            Member mentor,
+            Integer minAssignmentContentLength) {
         validateLiveStudy(type);
         return StudyV2.builder()
                 .type(type)
@@ -165,6 +166,7 @@ public class StudyV2 extends BaseEntity {
                 .discordChannelId(discordChannelId)
                 .discordRoleId(discordRoleId)
                 .mentor(mentor)
+                .minAssignmentContentLength(minAssignmentContentLength)
                 .build();
     }
 
@@ -184,7 +186,8 @@ public class StudyV2 extends BaseEntity {
             Period applicationPeriod,
             String discordChannelId,
             String discordRoleId,
-            Member mentor) {
+            Member mentor,
+            Integer minAssignmentContentLength) {
         return StudyV2.builder()
                 .type(StudyType.ASSIGNMENT)
                 .title(title)
@@ -194,6 +197,7 @@ public class StudyV2 extends BaseEntity {
                 .discordChannelId(discordChannelId)
                 .discordRoleId(discordRoleId)
                 .mentor(mentor)
+                .minAssignmentContentLength(minAssignmentContentLength)
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -98,6 +98,9 @@ public class StudyV2 extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member mentor;
 
+    @Comment("과제 최소 글자수")
+    private Integer minAssignmentContentLength;
+
     @OrderBy("position asc")
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudySessionV2> studySessions = new ArrayList<>();
@@ -116,7 +119,8 @@ public class StudyV2 extends BaseEntity {
             Period applicationPeriod,
             String discordChannelId,
             String discordRoleId,
-            Member mentor) {
+            Member mentor,
+            Integer minAssignmentContentLength) {
         this.type = type;
         this.title = title;
         this.description = description;
@@ -130,6 +134,7 @@ public class StudyV2 extends BaseEntity {
         this.discordChannelId = discordChannelId;
         this.discordRoleId = discordRoleId;
         this.mentor = mentor;
+        this.minAssignmentContentLength = minAssignmentContentLength;
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -236,6 +236,7 @@ public class StudyV2 extends BaseEntity {
         this.dayOfWeek = command.dayOfWeek();
         this.startTime = command.startTime();
         this.endTime = command.endTime();
+        this.minAssignmentContentLength = command.minAssignmentContentLength();
 
         command.studySessions().forEach(sessionCommand -> {
             getStudySessionForUpdate(sessionCommand.studySessionId()).update(sessionCommand);

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -99,7 +99,7 @@ public class StudyV2 extends BaseEntity {
     private Member mentor;
 
     @Comment("과제 최소 글자수")
-    private Integer minAssignmentContentLength;
+    private Integer minAssignmentLength;
 
     @OrderBy("position asc")
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -120,7 +120,7 @@ public class StudyV2 extends BaseEntity {
             String discordChannelId,
             String discordRoleId,
             Member mentor,
-            Integer minAssignmentContentLength) {
+            Integer minAssignmentLength) {
         this.type = type;
         this.title = title;
         this.description = description;
@@ -134,7 +134,7 @@ public class StudyV2 extends BaseEntity {
         this.discordChannelId = discordChannelId;
         this.discordRoleId = discordRoleId;
         this.mentor = mentor;
-        this.minAssignmentContentLength = minAssignmentContentLength;
+        this.minAssignmentLength = minAssignmentLength;
     }
 
     /**
@@ -152,7 +152,7 @@ public class StudyV2 extends BaseEntity {
             String discordChannelId,
             String discordRoleId,
             Member mentor,
-            Integer minAssignmentContentLength) {
+            Integer minAssignmentLength) {
         validateLiveStudy(type);
         return StudyV2.builder()
                 .type(type)
@@ -166,7 +166,7 @@ public class StudyV2 extends BaseEntity {
                 .discordChannelId(discordChannelId)
                 .discordRoleId(discordRoleId)
                 .mentor(mentor)
-                .minAssignmentContentLength(minAssignmentContentLength)
+                .minAssignmentLength(minAssignmentLength)
                 .build();
     }
 
@@ -187,7 +187,7 @@ public class StudyV2 extends BaseEntity {
             String discordChannelId,
             String discordRoleId,
             Member mentor,
-            Integer minAssignmentContentLength) {
+            Integer minAssignmentLength) {
         return StudyV2.builder()
                 .type(StudyType.ASSIGNMENT)
                 .title(title)
@@ -197,7 +197,7 @@ public class StudyV2 extends BaseEntity {
                 .discordChannelId(discordChannelId)
                 .discordRoleId(discordRoleId)
                 .mentor(mentor)
-                .minAssignmentContentLength(minAssignmentContentLength)
+                .minAssignmentLength(minAssignmentLength)
                 .build();
     }
 
@@ -236,7 +236,7 @@ public class StudyV2 extends BaseEntity {
         this.dayOfWeek = command.dayOfWeek();
         this.startTime = command.startTime();
         this.endTime = command.endTime();
-        this.minAssignmentContentLength = command.minAssignmentContentLength();
+        this.minAssignmentLength = command.minAssignmentLength();
 
         command.studySessions().forEach(sessionCommand -> {
             getStudySessionForUpdate(sessionCommand.studySessionId()).update(sessionCommand);

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/service/AssignmentHistoryGraderV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/service/AssignmentHistoryGraderV2.java
@@ -16,12 +16,13 @@ import lombok.extern.slf4j.Slf4j;
 @DomainService
 public class AssignmentHistoryGraderV2 {
 
-    private static final int MINIMUM_ASSIGNMENT_CONTENT_LENGTH = 300;
-
-    public void judge(AssignmentSubmissionFetcher assignmentSubmissionFetcher, AssignmentHistoryV2 assignmentHistory) {
+    public void judge(
+            AssignmentSubmissionFetcher assignmentSubmissionFetcher,
+            AssignmentHistoryV2 assignmentHistory,
+            int minimumAssignmentContentLength) {
         try {
             AssignmentSubmission assignmentSubmission = assignmentSubmissionFetcher.fetch();
-            judgeAssignmentSubmission(assignmentSubmission, assignmentHistory);
+            judgeAssignmentSubmission(assignmentSubmission, assignmentHistory, minimumAssignmentContentLength);
         } catch (CustomException e) {
             SubmissionFailureType failureType = translateException(e);
             assignmentHistory.fail(failureType);
@@ -29,8 +30,10 @@ public class AssignmentHistoryGraderV2 {
     }
 
     private void judgeAssignmentSubmission(
-            AssignmentSubmission assignmentSubmission, AssignmentHistoryV2 assignmentHistory) {
-        if (assignmentSubmission.contentLength() < MINIMUM_ASSIGNMENT_CONTENT_LENGTH) {
+            AssignmentSubmission assignmentSubmission,
+            AssignmentHistoryV2 assignmentHistory,
+            int minimumAssignmentContentLength) {
+        if (assignmentSubmission.contentLength() < minimumAssignmentContentLength) {
             assignmentHistory.fail(WORD_COUNT_INSUFFICIENT);
             return;
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyCommonDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyCommonDto.java
@@ -26,7 +26,7 @@ public record StudyCommonDto(
         LocalDateTime openingDate,
         Long mentorId,
         String mentorName,
-        Integer minAssignmentContentLength) {
+        Integer minAssignmentLength) {
     public static StudyCommonDto from(StudyV2 study) {
         return new StudyCommonDto(
                 study.getId(),
@@ -43,6 +43,6 @@ public record StudyCommonDto(
                 study.getOpeningDate(),
                 study.getMentor().getId(),
                 study.getMentor().getName(),
-                study.getMinAssignmentContentLength());
+                study.getMinAssignmentLength());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyCommonDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyCommonDto.java
@@ -25,7 +25,8 @@ public record StudyCommonDto(
         Period applicationPeriod,
         LocalDateTime openingDate,
         Long mentorId,
-        String mentorName) {
+        String mentorName,
+        Integer minAssignmentContentLength) {
     public static StudyCommonDto from(StudyV2 study) {
         return new StudyCommonDto(
                 study.getId(),
@@ -41,6 +42,7 @@ public record StudyCommonDto(
                 study.getApplicationPeriod(),
                 study.getOpeningDate(),
                 study.getMentor().getId(),
-                study.getMentor().getName());
+                study.getMentor().getName(),
+                study.getMinAssignmentContentLength());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyManagerDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyManagerDto.java
@@ -25,7 +25,8 @@ public record StudyManagerDto(
         String discordChannelId,
         String discordRoleId,
         Long mentorId,
-        String mentorName) {
+        String mentorName,
+        Integer minAssignmentContentLength) {
     public static StudyManagerDto from(StudyV2 study) {
         return new StudyManagerDto(
                 study.getId(),
@@ -42,6 +43,7 @@ public record StudyManagerDto(
                 study.getDiscordChannelId(),
                 study.getDiscordRoleId(),
                 study.getMentor().getId(),
-                study.getMentor().getName());
+                study.getMentor().getName(),
+                study.getMinAssignmentContentLength());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyManagerDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/dto/StudyManagerDto.java
@@ -26,7 +26,7 @@ public record StudyManagerDto(
         String discordRoleId,
         Long mentorId,
         String mentorName,
-        Integer minAssignmentContentLength) {
+        Integer minAssignmentLength) {
     public static StudyManagerDto from(StudyV2 study) {
         return new StudyManagerDto(
                 study.getId(),
@@ -44,6 +44,6 @@ public record StudyManagerDto(
                 study.getDiscordRoleId(),
                 study.getMentor().getId(),
                 study.getMentor().getName(),
-                study.getMinAssignmentContentLength());
+                study.getMinAssignmentLength());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyCreateRequest.java
@@ -21,6 +21,6 @@ public record StudyCreateRequest(
         @NotNull Period applicationPeriod,
         String discordChannelId,
         String discordRoleId,
-        @NotNull Integer minAssignmentContentLength) {
+        @NotNull Integer minAssignmentLength) {
     // TODO: 라이브 세션 관련 필드의 경우 VO로 묶기
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyCreateRequest.java
@@ -20,6 +20,7 @@ public record StudyCreateRequest(
         @Nullable LocalTime endTime,
         @NotNull Period applicationPeriod,
         String discordChannelId,
-        String discordRoleId) {
+        String discordRoleId,
+        @NotNull Integer minAssignmentContentLength) {
     // TODO: 라이브 세션 관련 필드의 경우 VO로 묶기
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
@@ -14,7 +14,7 @@ public record StudyUpdateRequest(
         DayOfWeek dayOfWeek,
         LocalTime startTime,
         LocalTime endTime,
-        Integer minAssignmentContentLength,
+        Integer minAssignmentLength,
         List<StudySessionUpdateDto> studySessions) {
     public record StudySessionUpdateDto(
             Long studySessionId,
@@ -44,7 +44,7 @@ public record StudyUpdateRequest(
                 dayOfWeek,
                 startTime,
                 endTime,
-                minAssignmentContentLength,
+                minAssignmentLength,
                 sessionCommands);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
@@ -3,18 +3,19 @@ package com.gdschongik.gdsc.domain.studyv2.dto.request;
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.studyv2.domain.StudyUpdateCommand;
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
 
 public record StudyUpdateRequest(
-        String title,
+        @NotNull String title,
         String description,
         String descriptionNotionLink,
         DayOfWeek dayOfWeek,
         LocalTime startTime,
         LocalTime endTime,
-        Integer minAssignmentLength,
+        @NotNull Integer minAssignmentLength,
         List<StudySessionUpdateDto> studySessions) {
     public record StudySessionUpdateDto(
             Long studySessionId,

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/StudyUpdateRequest.java
@@ -14,6 +14,7 @@ public record StudyUpdateRequest(
         DayOfWeek dayOfWeek,
         LocalTime startTime,
         LocalTime endTime,
+        Integer minAssignmentContentLength,
         List<StudySessionUpdateDto> studySessions) {
     public record StudySessionUpdateDto(
             Long studySessionId,
@@ -37,6 +38,13 @@ public record StudyUpdateRequest(
                 .toList();
 
         return new StudyUpdateCommand(
-                title, description, descriptionNotionLink, dayOfWeek, startTime, endTime, sessionCommands);
+                title,
+                description,
+                descriptionNotionLink,
+                dayOfWeek,
+                startTime,
+                endTime,
+                minAssignmentContentLength,
+                sessionCommands);
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/studyv2/application/AdminStudyServiceV2Test.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/studyv2/application/AdminStudyServiceV2Test.java
@@ -42,7 +42,8 @@ class AdminStudyServiceV2Test extends IntegrationTest {
                     STUDY_END_TIME,
                     STUDY_APPLICATION_PERIOD,
                     STUDY_DISCORD_CHANNEL_ID,
-                    STUDY_DISCORD_ROLE_ID);
+                    STUDY_DISCORD_ROLE_ID,
+                    MIN_ASSIGNMENT_CONTENT_LENGTH);
 
             // when
             adminStudyService.createStudy(request);
@@ -70,7 +71,8 @@ class AdminStudyServiceV2Test extends IntegrationTest {
                     STUDY_END_TIME,
                     STUDY_APPLICATION_PERIOD,
                     STUDY_DISCORD_CHANNEL_ID,
-                    STUDY_DISCORD_ROLE_ID);
+                    STUDY_DISCORD_ROLE_ID,
+                    MIN_ASSIGNMENT_CONTENT_LENGTH);
 
             // when
             adminStudyService.createStudy(request);
@@ -97,7 +99,8 @@ class AdminStudyServiceV2Test extends IntegrationTest {
                     STUDY_END_TIME,
                     STUDY_APPLICATION_PERIOD,
                     STUDY_DISCORD_CHANNEL_ID,
-                    STUDY_DISCORD_ROLE_ID);
+                    STUDY_DISCORD_ROLE_ID,
+                    MIN_ASSIGNMENT_CONTENT_LENGTH);
 
             // when
             adminStudyService.createStudy(request);

--- a/src/test/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2Test.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/studyv2/application/MentorStudyServiceV2Test.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.studyv2.application;
 
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.MIN_ASSIGNMENT_CONTENT_LENGTH;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
@@ -36,6 +37,7 @@ class MentorStudyServiceV2Test extends IntegrationTest {
                     null,
                     null,
                     null,
+                    MIN_ASSIGNMENT_CONTENT_LENGTH,
                     List.of(new StudyUpdateRequest.StudySessionUpdateDto(
                             1L, "수정된 1회차 스터디 제목", null, null, null, null, null)));
 

--- a/src/test/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyFactoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyFactoryTest.java
@@ -40,7 +40,8 @@ class StudyFactoryTest {
                 STUDY_DISCORD_CHANNEL_ID,
                 STUDY_DISCORD_ROLE_ID,
                 mentor,
-                generator);
+                generator,
+                MIN_ASSIGNMENT_CONTENT_LENGTH);
 
         // then
         assertThat(study.getStudySessions()).hasSize(8);
@@ -64,7 +65,8 @@ class StudyFactoryTest {
                 STUDY_DISCORD_CHANNEL_ID,
                 STUDY_DISCORD_ROLE_ID,
                 mentor,
-                null);
+                null,
+                MIN_ASSIGNMENT_CONTENT_LENGTH);
 
         // then
         assertThat(study.getDayOfWeek()).isNull();
@@ -92,7 +94,8 @@ class StudyFactoryTest {
                 STUDY_DISCORD_CHANNEL_ID,
                 STUDY_DISCORD_ROLE_ID,
                 mentor,
-                generator);
+                generator,
+                MIN_ASSIGNMENT_CONTENT_LENGTH);
 
         // then
         assertThat(study.getStudySessions())
@@ -119,7 +122,8 @@ class StudyFactoryTest {
                 STUDY_DISCORD_CHANNEL_ID,
                 STUDY_DISCORD_ROLE_ID,
                 mentor,
-                generator);
+                generator,
+                MIN_ASSIGNMENT_CONTENT_LENGTH);
 
         // then
         assertThat(study.getStudySessions())
@@ -145,7 +149,8 @@ class StudyFactoryTest {
                 STUDY_DISCORD_CHANNEL_ID,
                 STUDY_DISCORD_ROLE_ID,
                 mentor,
-                null);
+                null,
+                MIN_ASSIGNMENT_CONTENT_LENGTH);
 
         // then
         assertThat(study.getStudySessions())

--- a/src/test/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2Test.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2Test.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.studyv2.domain;
 
+import static com.gdschongik.gdsc.global.common.constant.StudyConstant.MIN_ASSIGNMENT_CONTENT_LENGTH;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -40,6 +41,7 @@ class StudyV2Test {
                     null,
                     null,
                     null,
+                    MIN_ASSIGNMENT_CONTENT_LENGTH,
                     List.of(new StudyUpdateCommand.Session(
                             1L, updatedFirstSessionTitle, null, null, null, null, null)));
 
@@ -68,6 +70,7 @@ class StudyV2Test {
                     null,
                     null,
                     null,
+                    MIN_ASSIGNMENT_CONTENT_LENGTH,
                     List.of(new StudyUpdateCommand.Session(1L, null, null, lessonPeriodToUpdate, null, null, null)));
 
             // when & then
@@ -88,6 +91,7 @@ class StudyV2Test {
                     null,
                     null,
                     null,
+                    MIN_ASSIGNMENT_CONTENT_LENGTH,
                     List.of(new StudyUpdateCommand.Session(9999L, null, null, null, null, null, null)));
 
             // when & then
@@ -116,7 +120,7 @@ class StudyV2Test {
             List<StudyUpdateCommand.Session> sessions = IntStream.range(0, dates.length)
                     .mapToObj(i -> createSession((long) (i + 1), dates[i]))
                     .toList();
-            return new StudyUpdateCommand(null, null, null, null, null, null, sessions);
+            return new StudyUpdateCommand(null, null, null, null, null, null, MIN_ASSIGNMENT_CONTENT_LENGTH, sessions);
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/StudyConstant.java
@@ -31,6 +31,7 @@ public class StudyConstant {
     public static final String ATTENDANCE_NUMBER = "1234";
 
     // Assignment
+    public static final int MIN_ASSIGNMENT_CONTENT_LENGTH = 200;
     public static final String ASSIGNMENT_TITLE = "testTitle";
     public static final String DESCRIPTION_LINK = "www.link.com";
 

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -147,7 +147,8 @@ public class FixtureHelper {
                 STUDY_DISCORD_CHANNEL_ID,
                 STUDY_DISCORD_ROLE_ID,
                 createMentor(mentorId),
-                () -> "0000");
+                () -> "0000",
+                MIN_ASSIGNMENT_CONTENT_LENGTH);
 
         setId(study, studyId);
 

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -317,7 +317,8 @@ public abstract class IntegrationTest {
                 STUDY_DISCORD_CHANNEL_ID,
                 STUDY_DISCORD_ROLE_ID,
                 mentor,
-                () -> "0000");
+                () -> "0000",
+                MIN_ASSIGNMENT_CONTENT_LENGTH);
 
         return studyV2Repository.save(study);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1050

## 📌 작업 내용 및 특이사항
- 스터디에 최소 과제 글자수 필드를 추가했습니다.
- 스터디 조회, 생성, 수정시에 반영되도록 변경했습니다.

## 📝 참고사항
- 스터디 v2 DB column 이 변경되었습니다. 
- 다음 prod 배포하는 분은 반드시 DB column 먼저 변경해야 하는 점 잊으면 안될 듯 합니다. 
(study_v2 테이블에 min_assignment_content_length 추가)

## 📚 기타
- `StudyCreateRequest`에는 스터디 제목을 포함한 몇몇 필드가 `@NotNull` 처리되어 있는데, 
`StudyUpdateRequest` 에는 null 검증이 없습니다. 이유가 있나요??


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 스터디 생성 및 수정 시 과제 최소 글자 수(minAssignmentLength)를 설정할 수 있는 기능이 추가되었습니다.
  - 스터디 정보 조회 시 과제 최소 글자 수가 함께 제공됩니다.

- **버그 수정**
  - 과제 제출 시 설정된 최소 글자 수를 기준으로 제출 여부가 판정됩니다.

- **테스트**
  - 과제 최소 글자 수 관련 테스트 케이스가 추가 및 보완되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->