### PR TITLE
feat: 학생 스터디 공지 관련 컴포넌트에 `Student` prefix 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyAnnouncementControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyAnnouncementControllerV2.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.studyv2.api;
 
-import com.gdschongik.gdsc.domain.studyv2.application.StudyAnnouncementServiceV2;
+import com.gdschongik.gdsc.domain.studyv2.application.StudentStudyAnnouncementServiceV2;
 import com.gdschongik.gdsc.domain.studyv2.dto.response.StudyAnnouncementResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,25 +12,25 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Study Announcement V2", description = "스터디 공지 V2 API입니다.")
+@Tag(name = "Student Study Announcement V2", description = "학생 스터디 공지 V2 API입니다.")
 @RestController
 @RequestMapping("/v2/study-announcements")
 @RequiredArgsConstructor
-public class StudyAnnouncementControllerV2 {
+public class StudentStudyAnnouncementControllerV2 {
 
-    private final StudyAnnouncementServiceV2 studyAnnouncementServiceV2;
+    private final StudentStudyAnnouncementServiceV2 studentStudyAnnouncementServiceV2;
 
     @Operation(summary = "수강중인 특정 스터디의 공지 목록 조회", description = "나의 수강중인 특정 스터디의 공지 목록을 조회합니다.")
     @GetMapping("/{studyId}/me")
     public ResponseEntity<List<StudyAnnouncementResponse>> getStudyAnnouncements(@PathVariable Long studyId) {
-        var response = studyAnnouncementServiceV2.getStudyAnnouncements(studyId);
+        var response = studentStudyAnnouncementServiceV2.getStudyAnnouncements(studyId);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "수강중인 모든 스터디의 공지 목록 조회", description = "나의 수강중인 모든 스터디의 공지 목록을 조회합니다")
     @GetMapping("/me")
     public ResponseEntity<List<StudyAnnouncementResponse>> getStudiesAnnouncements() {
-        var response = studyAnnouncementServiceV2.getStudiesAnnouncements();
+        var response = studentStudyAnnouncementServiceV2.getStudiesAnnouncements();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyAnnouncementServiceV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/application/StudentStudyAnnouncementServiceV2.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class StudyAnnouncementServiceV2 {
+public class StudentStudyAnnouncementServiceV2 {
 
     private final MemberUtil memberUtil;
     private final RecruitmentRepository recruitmentRepository;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1054

## 📌 작업 내용 및 특이사항
- controller와 service 이름에 누락된 Student prefix 추가했습니다

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 학생 전용 스터디 공지사항 관련 컨트롤러 및 서비스 명칭이 보다 명확하게 변경되었습니다.  
  - API 문서 내 태그 및 설명이 학생 전용 스터디 공지사항으로 업데이트되었습니다.  
  - 서비스 및 컨트롤러 이름이 일관성 있게 조정되었습니다.  
  - 기존 기능과 엔드포인트에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->