### PR TITLE
chore: swagger 정렬

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/api/AdminCouponController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/api/AdminCouponController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Admin Coupon", description = "어드민 쿠폰 관리 API입니다.")
+@Tag(name = "Coupon - Admin", description = "어드민 쿠폰 관리 API입니다.")
 @RestController
 @RequestMapping("/admin/coupons")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/coupon/api/OnboardingCouponController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/coupon/api/OnboardingCouponController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Onboarding Coupon", description = "온보딩 쿠폰 API입니다.")
+@Tag(name = "Coupon - Onboarding", description = "온보딩 쿠폰 API입니다.")
 @RestController
 @RequestMapping("/onboarding/coupons")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/api/OnboardingDiscordController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Onboarding Discord", description = "온보딩 서비스의 디스코드 관련 API입니다.")
+@Tag(name = "Discord - Onboarding", description = "온보딩 서비스의 디스코드 관련 API입니다.")
 @RestController
 @RequestMapping("/onboarding")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/email/api/OnboardingUnivEmailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/email/api/OnboardingUnivEmailController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Univ Email", description = "학교 인증 메일 인증 API입니다.")
+@Tag(name = "Email - Onboarding", description = "학교 인증 메일 인증 API입니다.")
 @RestController
 @RequestMapping("/onboarding")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/AdminMemberController.java
@@ -17,7 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Admin Member", description = "어드민 회원 관리 API입니다.")
+@Tag(name = "Member - Admin", description = "어드민 회원 관리 API입니다.")
 @RestController
 @RequestMapping("/admin/members")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/CommonMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/CommonMemberController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Common Member", description = "공통 멤버 API입니다.")
+@Tag(name = "Member - common", description = "공통 멤버 API입니다.")
 @RestController
 @RequestMapping("/common/members")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/CommonMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/CommonMemberController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Member - common", description = "공통 멤버 API입니다.")
+@Tag(name = "Member - Common", description = "공통 멤버 API입니다.")
 @RestController
 @RequestMapping("/common/members")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/OnboardingMemberController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Onboarding Member", description = "회원 온보딩 API입니다.")
+@Tag(name = "Member - Onboarding", description = "회원 온보딩 API입니다.")
 @RestController
 @RequestMapping("/onboarding/members")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/api/TestMemberController.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Test Member", description = "회원 테스트용 API입니다. dev 환경에서만 사용 가능합니다")
+@Tag(name = "Member - Test", description = "회원 테스트용 API입니다. local,dev 환경에서만 사용 가능합니다")
 @RestController
 @RequestMapping("/test/members")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/order/api/AdminOrderController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/api/AdminOrderController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Admin Order", description = "주문 어드민 API입니다.")
+@Tag(name = "Order - Admin", description = "주문 어드민 API입니다.")
 @RestController
 @RequestMapping("/admin/orders")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/order/api/OnboardingOrderController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/api/OnboardingOrderController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Onboarding Order", description = "주문 온보딩 API입니다.")
+@Tag(name = "Order - Onboarding", description = "주문 온보딩 API입니다.")
 @RestController
 @RequestMapping("/onboarding/orders")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/api/AdminRecruitmentController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Admin Recruitment", description = "어드민 리쿠르팅 관리 API입니다.")
+@Tag(name = "Recruitment - Admin", description = "어드민 리쿠르팅 관리 API입니다.")
 @RestController
 @RequestMapping("/admin/recruitments")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/AdminStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/AdminStudyController.java
@@ -15,7 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Admin Study", description = "어드민 스터디 API입니다.")
+@Deprecated
+@Tag(name = "Study V1 - Admin", description = "어드민 스터디 API입니다.")
 @RestController
 @RequestMapping("/admin/studies")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/CommonStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/CommonStudyController.java
@@ -13,7 +13,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Common Study", description = "공통 스터디 API입니다.")
+@Deprecated
+@Tag(name = "Study V1 - Common", description = "공통 스터디 API입니다.")
 @RestController
 @RequestMapping("/common/studies")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyAchievementController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyAchievementController.java
@@ -13,7 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Mentor StudyAchievement", description = "멘토 스터디 우수 스터디원 관리 API입니다.")
+@Deprecated
+@Tag(name = "Study Achievement V1 - Mentor", description = "멘토 스터디 우수 스터디원 관리 API입니다.")
 @RestController
 @RequestMapping("/mentor/study-achievements")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyController.java
@@ -17,7 +17,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Mentor Study", description = "멘토 스터디 API입니다.")
+@Deprecated
+@Tag(name = "Study V1 - Mentor", description = "멘토 스터디 API입니다.")
 @RestController
 @RequestMapping("/mentor/studies")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyDetailController.java
@@ -21,7 +21,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Mentor StudyDetail", description = "멘토 스터디 상세 관리 API입니다.")
+@Deprecated
+@Tag(name = "Study Detail V1- Mentor", description = "멘토 스터디 상세 관리 API입니다.")
 @RestController
 @RequestMapping("/mentor/study-details")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyHistoryController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/MentorStudyHistoryController.java
@@ -11,7 +11,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Mentor Study History", description = "멘토 스터디 수강 이력 API입니다.")
+@Deprecated
+@Tag(name = "Study History V1 - Mentor", description = "멘토 스터디 수강 이력 API입니다.")
 @RestController
 @RequestMapping("/mentor/study-history")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyController.java
@@ -17,7 +17,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Student Study", description = "사용자 스터디 API입니다.")
+@Deprecated
+@Tag(name = "Study V1 - Student", description = "사용자 스터디 API입니다.")
 @RestController
 @RequestMapping("/studies")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyDetailController.java
@@ -15,7 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Student Study Detail", description = "수강자 스터디 상세 API입니다.")
+@Deprecated
+@Tag(name = "Study Detail V1 - Student", description = "수강자 스터디 상세 API입니다.")
 @RestController
 @RequestMapping("/study-details")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyHistoryController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/api/StudentStudyHistoryController.java
@@ -13,7 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Student Study History", description = "사용자 스터디 수강 이력 API입니다.")
+@Deprecated
+@Tag(name = "Study History V1 - Student", description = "사용자 스터디 수강 이력 API입니다.")
 @RestController
 @RequestMapping("/study-history")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/AdminStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/AdminStudyControllerV2.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Admin Study V2", description = "스터디 V2 어드민 API입니다.")
+@Tag(name = "Study V2 - Admin", description = "스터디 V2 어드민 API입니다.")
 @RestController
 @RequestMapping("/v2/admin/studies")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/CommonStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/CommonStudyControllerV2.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Common Study V2", description = "공통 스터디 V2 API입니다.")
+@Tag(name = "Study V2 - Common", description = "공통 스터디 V2 API입니다.")
 @RestController
 @RequestMapping("/v2/common/studies")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyAchievementControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyAchievementControllerV2.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Mentor StudyAchievement V2", description = "멘토 스터디 우수 스터디원 관리 V2 API입니다.")
+@Tag(name = "Study Achievement V2 - Mentor", description = "멘토 스터디 우수 스터디원 관리 V2 API입니다.")
 @RestController
 @RequestMapping("/v2/mentor/study-achievements")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyAnnouncementControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyAnnouncementControllerV2.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Mentor Study Announcement V2", description = "스터디 공지 V2 멘토 API입니다.")
+@Tag(name = "Study Announcement V2 - Mentor", description = "스터디 공지 V2 멘토 API입니다.")
 @RestController
 @RequestMapping("/v2/mentor/study-announcements")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyControllerV2.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Mentor Study V2", description = "스터디 V2 멘토 API입니다.")
+@Tag(name = "Study V2 - Mentor", description = "스터디 V2 멘토 API입니다.")
 @RestController
 @RequestMapping("/v2/mentor/studies")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyHistoryControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/MentorStudyHistoryControllerV2.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Mentor Study History V2", description = "멘토 스터디 수강 이력 API입니다.")
+@Tag(name = "Study History V2 - Mentor", description = "멘토 스터디 수강 이력 API입니다.")
 @RestController
 @RequestMapping("/v2/mentor/study-histories")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentAssignmentHistoryControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentAssignmentHistoryControllerV2.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Student Assignment History V2", description = "학생 과제 제출이력 API입니다.")
+@Tag(name = "Study Assignment History V2 - Student", description = "학생 과제 제출이력 API입니다.")
 @RestController
 @RequestMapping("/v2/assignment-histories")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentAttendanceControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentAttendanceControllerV2.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Student Study Attendance V2", description = "사용자 스터디 출석체크 V2 API입니다.")
+@Tag(name = "Study Attendance V2 - Student", description = "사용자 스터디 출석체크 V2 API입니다.")
 @RestController
 @RequestMapping("/v2/attendances")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyAnnouncementControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyAnnouncementControllerV2.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Student Study Announcement V2", description = "학생 스터디 공지 V2 API입니다.")
+@Tag(name = "Study Announcement V2 - Student", description = "학생 스터디 공지 V2 API입니다.")
 @RestController
 @RequestMapping("/v2/study-announcements")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyControllerV2.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Student Study V2", description = "학생 스터디 API입니다.")
+@Tag(name = "Study V2 - Student", description = "학생 스터디 API입니다.")
 @RestController
 @RequestMapping("/v2/studies")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/api/StudentStudyHistoryControllerV2.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Student Study History V2", description = "학생 스터디 수강이력 API입니다.")
+@Tag(name = "Study History V2 - Student", description = "학생 스터디 수강이력 API입니다.")
 @RestController
 @RequestMapping("/v2/study-histories")
 @RequiredArgsConstructor

--- a/src/main/java/com/gdschongik/gdsc/global/config/SwaggerConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/SwaggerConfig.java
@@ -10,12 +10,10 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
-
+import io.swagger.v3.oas.models.tags.Tag;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-
-import io.swagger.v3.oas.models.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/gdschongik/gdsc/global/config/SwaggerConfig.java
+++ b/src/main/java/com/gdschongik/gdsc/global/config/SwaggerConfig.java
@@ -10,8 +10,14 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+
+import io.swagger.v3.oas.models.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,6 +33,38 @@ public class SwaggerConfig {
                 .servers(swaggerServers())
                 .addSecurityItem(securityRequirement())
                 .components(authSetting());
+    }
+
+    @Bean
+    public OpenApiCustomizer openApiCustomizer() {
+        return openApi -> {
+            List<Tag> topPriorityTags = new ArrayList<>();
+            List<Tag> bottomPriorityTags = new ArrayList<>();
+            List<Tag> middlePriorityTags = new ArrayList<>();
+
+            for (Tag tag : openApi.getTags()) {
+                String tagName = tag.getName();
+                if ("Member - Test".equals(tagName)) { // Test용 토큰 생성 API는 최상단 우선순위
+                    topPriorityTags.add(tag);
+                } else if (tagName.contains("Study") && tagName.contains("V1")) { // Study V1 API는 최하단 우선순위
+                    bottomPriorityTags.add(tag);
+                } else {
+                    middlePriorityTags.add(tag);
+                }
+            }
+
+            // 우선순위별로 태그를 합치고, 각 그룹 내에서 알파벳 순으로 정렬
+            List<Tag> sortedTags = new ArrayList<>();
+            topPriorityTags.sort(Comparator.comparing(Tag::getName));
+            middlePriorityTags.sort(Comparator.comparing(Tag::getName));
+            bottomPriorityTags.sort(Comparator.comparing(Tag::getName));
+
+            sortedTags.addAll(topPriorityTags);
+            sortedTags.addAll(middlePriorityTags);
+            sortedTags.addAll(bottomPriorityTags);
+
+            openApi.setTags(sortedTags);
+        };
     }
 
     private List<Server> swaggerServers() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1063

## 📌 작업 내용 및 특이사항
- 스웨거 API들을 정렬했습니다.
- 테스트용 멤버 API (테스트용 토큰 발급) API를 최상단으로 정렬했습니다.
- Study V1 API들에 `@Deprecated`를 추가 후 최하단으로 정렬했습니다.

## 📝 참고사항
- yml을 이용한 설정은 알파벳 정렬 등과 같은 간단한 기능만 제공해 설정 코드를 추가했습니다.
- 태그 이름이 아니라 `@Deprecated` 어노테이션을 직접 찾아내서 정렬하는 코드를 찾아보려 했는데 `@Tag` (컨트롤러 클래스) 수준이 아니라 `@Operation` (메서드) 수준에서 deprecated 여부 조회만 지원해주는걸로 보여 Tag 이름으로 직접 정렬했습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Swagger/OpenAPI 문서에서 API 그룹(tag) 이름이 일관성 있게 변경되었습니다. 예: "Admin Coupon" → "Coupon - Admin", "Student Study V2" → "Study V2 - Student" 등.
  - 일부 컨트롤러가 deprecated(사용 중단 예정)으로 표시되어 문서에서 구분이 명확해졌습니다.
  - Swagger UI에서 API 그룹(tag) 정렬 방식이 개선되어, "Member - Test"가 최상위에, "Study V1" 관련 그룹이 하위에 정렬됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->