### PR TITLE
refactor: Recruitment 엔티티에 Semester 필드 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseSemesterEntity.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/model/BaseSemesterEntity.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.common.model;
 
-import com.gdschongik.gdsc.domain.common.vo.Semester;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
@@ -19,8 +18,4 @@ public abstract class BaseSemesterEntity extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private SemesterType semesterType;
-
-    public Semester getSemester() {
-        return Semester.of(academicYear, semesterType);
-    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/application/AdminMemberService.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.member.application;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberRole;
@@ -67,8 +68,8 @@ public class AdminMemberService {
 
     @Transactional
     public void demoteAllRegularMembersToAssociate(MemberDemoteRequest request) {
-        List<RecruitmentRound> recruitmentRounds = recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(
-                request.academicYear(), request.semesterType());
+        List<RecruitmentRound> recruitmentRounds = recruitmentRoundRepository.findAllBySemester(
+                Semester.of(request.academicYear(), request.semesterType()));
         LocalDateTime now = LocalDateTime.now();
 
         memberValidator.validateMemberDemote(recruitmentRounds, now);

--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -95,9 +95,12 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository, Membe
         return semester != null
                 ? membership
                         .recruitmentRound
+                        .recruitment
+                        .semester
                         .academicYear
                         .eq(semester.getAcademicYear())
-                        .and(membership.recruitmentRound.semesterType.eq(semester.getSemesterType()))
+                        .and(membership.recruitmentRound.recruitment.semester.semesterType.eq(
+                                semester.getSemesterType()))
                 : null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderCustomRepositoryImpl.java
@@ -46,8 +46,8 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository, OrderQu
     private QOrderAdminResponse getOrderAdminResponse() {
         return new QOrderAdminResponse(
                 order.id,
-                recruitmentRound.academicYear,
-                recruitmentRound.semesterType,
+                recruitmentRound.recruitment.semester.academicYear,
+                recruitmentRound.recruitment.semester.semesterType,
                 member.name,
                 order.status,
                 member.studentId,

--- a/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/order/dao/OrderQueryMethod.java
@@ -39,11 +39,11 @@ public interface OrderQueryMethod {
     }
 
     default BooleanExpression eqAcademicYear(Integer academicYear) {
-        return academicYear != null ? recruitmentRound.academicYear.eq(academicYear) : null;
+        return academicYear != null ? recruitmentRound.recruitment.semester.academicYear.eq(academicYear) : null;
     }
 
     default BooleanExpression eqSemesterType(SemesterType semesterType) {
-        return semesterType != null ? recruitmentRound.semesterType.eq(semesterType) : null;
+        return semesterType != null ? recruitmentRound.recruitment.semester.semesterType.eq(semesterType) : null;
     }
 
     default BooleanExpression eqStudentId(String studentId) {

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -66,12 +66,13 @@ public class AdminRecruitmentService {
 
     @Transactional
     public void createRecruitmentRound(RecruitmentRoundCreateRequest request) {
+        Semester semester = Semester.of(request.academicYear(), request.semesterType());
+
         Recruitment recruitment = recruitmentRepository
-                .findBySemester(Semester.of(request.academicYear(), request.semesterType()))
+                .findBySemester(semester)
                 .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
 
-        List<RecruitmentRound> recruitmentRoundsInThisSemester = recruitmentRoundRepository.findAllBySemester(
-                Semester.of(request.academicYear(), request.semesterType()));
+        List<RecruitmentRound> recruitmentRoundsInThisSemester = recruitmentRoundRepository.findAllBySemester(semester);
 
         recruitmentRoundValidator.validateRecruitmentRoundCreate(
                 request.startDate(),

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentService.java
@@ -4,6 +4,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRepository;
 import com.gdschongik.gdsc.domain.recruitment.dao.RecruitmentRoundRepository;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
@@ -36,8 +37,8 @@ public class AdminRecruitmentService {
 
     @Transactional
     public void createRecruitment(RecruitmentCreateRequest request) {
-        boolean isRecruitmentOverlap = recruitmentRepository.existsByAcademicYearAndSemesterType(
-                request.academicYear(), request.semesterType());
+        Semester semester = Semester.of(request.academicYear(), request.semesterType());
+        boolean isRecruitmentOverlap = recruitmentRepository.existsBySemester(semester);
 
         recruitmentValidator.validateRecruitmentCreate(isRecruitmentOverlap);
 
@@ -45,8 +46,7 @@ public class AdminRecruitmentService {
                 request.feeName(),
                 Money.from(request.fee()),
                 Period.of(request.semesterStartDate(), request.semesterEndDate()),
-                request.academicYear(),
-                request.semesterType());
+                semester);
         recruitmentRepository.save(recruitment);
 
         log.info("[AdminRecruitmentService] 리쿠르팅 생성: recruitmentId={}", recruitment.getId());
@@ -67,12 +67,11 @@ public class AdminRecruitmentService {
     @Transactional
     public void createRecruitmentRound(RecruitmentRoundCreateRequest request) {
         Recruitment recruitment = recruitmentRepository
-                .findByAcademicYearAndSemesterType(request.academicYear(), request.semesterType())
+                .findBySemester(Semester.of(request.academicYear(), request.semesterType()))
                 .orElseThrow(() -> new CustomException(RECRUITMENT_NOT_FOUND));
 
-        List<RecruitmentRound> recruitmentRoundsInThisSemester =
-                recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(
-                        request.academicYear(), request.semesterType());
+        List<RecruitmentRound> recruitmentRoundsInThisSemester = recruitmentRoundRepository.findAllBySemester(
+                Semester.of(request.academicYear(), request.semesterType()));
 
         recruitmentRoundValidator.validateRecruitmentRoundCreate(
                 request.startDate(),
@@ -90,8 +89,8 @@ public class AdminRecruitmentService {
 
     @Transactional
     public void updateRecruitmentRound(Long recruitmentRoundId, RecruitmentRoundUpdateRequest request) {
-        List<RecruitmentRound> recruitmentRounds = recruitmentRoundRepository.findAllByAcademicYearAndSemesterType(
-                request.academicYear(), request.semesterType());
+        List<RecruitmentRound> recruitmentRounds = recruitmentRoundRepository.findAllBySemester(
+                Semester.of(request.academicYear(), request.semesterType()));
 
         RecruitmentRound recruitmentRound = recruitmentRounds.stream()
                 .filter(r -> r.getId().equals(recruitmentRoundId))

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRepository.java
@@ -1,6 +1,6 @@
 package com.gdschongik.gdsc.domain.recruitment.dao;
 
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import java.util.List;
 import java.util.Optional;
@@ -8,9 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentCustomRepository {
 
-    boolean existsByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
+    boolean existsBySemester(Semester semester);
 
     List<Recruitment> findByOrderBySemesterPeriodDesc();
 
-    Optional<Recruitment> findByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
+    Optional<Recruitment> findBySemester(Semester semester);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundCustomRepository.java
@@ -1,0 +1,10 @@
+package com.gdschongik.gdsc.domain.recruitment.dao;
+
+import com.gdschongik.gdsc.domain.common.vo.Semester;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import java.util.List;
+
+public interface RecruitmentRoundCustomRepository {
+
+    List<RecruitmentRound> findAllBySemester(Semester semester);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundCustomRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.recruitment.dao;
+
+import static com.gdschongik.gdsc.domain.recruitment.domain.QRecruitmentRound.recruitmentRound;
+
+import com.gdschongik.gdsc.domain.common.vo.Semester;
+import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RecruitmentRoundCustomRepositoryImpl implements RecruitmentRoundCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<RecruitmentRound> findAllBySemester(Semester semester) {
+        return queryFactory
+                .selectFrom(recruitmentRound)
+                .where(recruitmentRound.recruitment.semester.eq(semester))
+                .fetch();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dao/RecruitmentRoundRepository.java
@@ -1,11 +1,7 @@
 package com.gdschongik.gdsc.domain.recruitment.dao;
 
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RecruitmentRoundRepository extends JpaRepository<RecruitmentRound, Long> {
-
-    List<RecruitmentRound> findAllByAcademicYearAndSemesterType(Integer academicYear, SemesterType semesterType);
-}
+public interface RecruitmentRoundRepository
+        extends JpaRepository<RecruitmentRound, Long>, RecruitmentRoundCustomRepository {}

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/Recruitment.java
@@ -1,9 +1,9 @@
 package com.gdschongik.gdsc.domain.recruitment.domain;
 
-import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Recruitment extends BaseSemesterEntity {
+public class Recruitment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,25 +26,25 @@ public class Recruitment extends BaseSemesterEntity {
     private Money fee;
 
     @Embedded
+    private Semester semester;
+
+    @Embedded
     private Period semesterPeriod;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Recruitment(
-            String feeName, Money fee, final Period semesterPeriod, Integer academicYear, SemesterType semesterType) {
-        super(academicYear, semesterType);
+    private Recruitment(String feeName, Money fee, final Period semesterPeriod, Semester semester) {
         this.feeName = feeName;
         this.fee = fee;
         this.semesterPeriod = semesterPeriod;
+        this.semester = semester;
     }
 
-    public static Recruitment create(
-            String feeName, Money fee, Period semesterPeriod, Integer academicYear, SemesterType semesterType) {
+    public static Recruitment create(String feeName, Money fee, Period semesterPeriod, Semester semester) {
         return Recruitment.builder()
                 .feeName(feeName)
                 .fee(fee)
                 .semesterPeriod(semesterPeriod)
-                .academicYear(academicYear)
-                .semesterType(semesterType)
+                .semester(semester)
                 .build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -44,11 +44,7 @@ public class RecruitmentRound extends BaseEntity {
     private Recruitment recruitment;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private RecruitmentRound(
-            RoundType roundType,
-            String name,
-            final Period period,
-            Recruitment recruitment) {
+    private RecruitmentRound(RoundType roundType, String name, final Period period, Recruitment recruitment) {
         this.name = name;
         this.roundType = roundType;
         this.period = period;

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -2,8 +2,7 @@ package com.gdschongik.gdsc.domain.recruitment.domain;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
-import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Column;
@@ -25,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RecruitmentRound extends BaseSemesterEntity {
+public class RecruitmentRound extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,10 +48,7 @@ public class RecruitmentRound extends BaseSemesterEntity {
             RoundType roundType,
             String name,
             final Period period,
-            Recruitment recruitment,
-            Integer academicYear,
-            SemesterType semesterType) {
-        super(academicYear, semesterType);
+            Recruitment recruitment) {
         this.name = name;
         this.roundType = roundType;
         this.period = period;
@@ -65,8 +61,6 @@ public class RecruitmentRound extends BaseSemesterEntity {
                 .name(name)
                 .period(period)
                 .recruitment(recruitment)
-                .academicYear(recruitment.getAcademicYear())
-                .semesterType(recruitment.getSemesterType())
                 .build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/response/AdminRecruitmentResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/response/AdminRecruitmentResponse.java
@@ -19,7 +19,7 @@ public record AdminRecruitmentResponse(
 
         return new AdminRecruitmentResponse(
                 recruitment.getId(),
-                SemesterFormatter.format(recruitment),
+                SemesterFormatter.format(recruitment.getSemester()),
                 recruitment.getSemesterPeriod().getStartDate(),
                 recruitment.getSemesterPeriod().getEndDate(),
                 String.format("%s원", decimalFormat.format(recruitment.getFee().getAmount())),

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/response/AdminRecruitmentRoundResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/dto/response/AdminRecruitmentRoundResponse.java
@@ -17,7 +17,7 @@ public record AdminRecruitmentRoundResponse(
 
         return new AdminRecruitmentRoundResponse(
                 recruitmentRound.getId(),
-                SemesterFormatter.format(recruitmentRound),
+                SemesterFormatter.format(recruitmentRound.getRecruitment().getSemester()),
                 recruitmentRound.getPeriod().getStartDate(),
                 recruitmentRound.getPeriod().getEndDate(),
                 recruitmentRound.getName(),

--- a/src/main/java/com/gdschongik/gdsc/global/util/formatter/SemesterFormatter.java
+++ b/src/main/java/com/gdschongik/gdsc/global/util/formatter/SemesterFormatter.java
@@ -2,13 +2,14 @@ package com.gdschongik.gdsc.global.util.formatter;
 
 import com.gdschongik.gdsc.domain.common.model.BaseSemesterEntity;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SemesterFormatter {
-    public static String format(BaseSemesterEntity semesterEntity) {
-        return format(semesterEntity.getAcademicYear(), semesterEntity.getSemesterType());
+    public static String format(Semester semester) {
+        return format(semester.getAcademicYear(), semester.getSemesterType());
     }
 
     public static String format(Integer academicYear, SemesterType semesterType) {

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -25,8 +25,7 @@ public class MemberValidatorTest {
         @Test
         void 해당_학기에_이미_시작된_모집기간이_있다면_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
             LocalDateTime now = LocalDateTime.now();
             RecruitmentRound recruitmentRound = RecruitmentRound.create(
                     RECRUITMENT_ROUND_NAME, ROUND_TYPE, Period.of(now.minusDays(1), now.plusDays(1)), recruitment);

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipTest.java
@@ -8,6 +8,7 @@ import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
 import com.gdschongik.gdsc.domain.recruitment.domain.RecruitmentRound;
@@ -29,7 +30,10 @@ class MembershipTest {
             member.advanceToAssociate();
 
             Recruitment recruitment = Recruitment.create(
-                    FEE_NAME, FEE, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), ACADEMIC_YEAR, SEMESTER_TYPE);
+                    FEE_NAME,
+                    FEE,
+                    Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE),
+                    Semester.of(ACADEMIC_YEAR, SEMESTER_TYPE));
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/membership/domain/MembershipValidatorTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.membership.domain.service.MembershipValidator;
 import com.gdschongik.gdsc.domain.recruitment.domain.Recruitment;
@@ -42,7 +43,10 @@ class MembershipValidatorTest {
             LocalDateTime startDate,
             LocalDateTime endDate) {
         Recruitment recruitment = Recruitment.create(
-                FEE_NAME, fee, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), academicYear, semesterType);
+                FEE_NAME,
+                fee,
+                Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE),
+                Semester.of(academicYear, semesterType));
         return RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, Period.of(startDate, endDate), recruitment);
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/application/AdminRecruitmentServiceTest.java
@@ -70,8 +70,7 @@ class AdminRecruitmentServiceTest extends IntegrationTest {
         void 성공한다() {
             // given
             LocalDateTime now = LocalDateTime.now().withNano(0);
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, Period.of(now, now.plusMonths(3)), ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, Period.of(now, now.plusMonths(3)), SEMESTER);
             recruitmentRepository.save(recruitment);
 
             RecruitmentRound recruitmentRound = RecruitmentRound.create(

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -5,8 +5,8 @@ import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
-import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.recruitment.domain.service.RecruitmentRoundValidator;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.time.LocalDateTime;
@@ -29,8 +29,7 @@ public class RecruitmentRoundValidatorTest {
                     FEE_NAME,
                     FEE,
                     Period.of(LocalDateTime.of(2025, 3, 2, 0, 0), LocalDateTime.of(2025, 8, 31, 0, 0)),
-                    2025,
-                    SEMESTER_TYPE);
+                    Semester.of(2025, SEMESTER_TYPE));
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -46,8 +45,7 @@ public class RecruitmentRoundValidatorTest {
                     FEE_NAME,
                     FEE,
                     Period.of(LocalDateTime.of(2024, 9, 1, 0, 0), LocalDateTime.of(2025, 2, 28, 0, 0)),
-                    ACADEMIC_YEAR,
-                    SemesterType.SECOND);
+                    SEMESTER);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -59,8 +57,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void 모집_시작일과_종료일이_학기_시작일로부터_2주_이내에_있지_않다면_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -72,8 +69,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void 학년도_학기_차수가_모두_중복되면_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
 
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
@@ -92,8 +88,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void RoundType_1차가_없을때_2차를_생성하려_하면_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
 
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
@@ -105,8 +100,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void 기간이_중복되는_모집회차가_있다면_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
 
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
@@ -125,8 +119,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void 기간이_중복되는_모집회차가_있다면_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
 
             RecruitmentRound firstRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
@@ -151,8 +144,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void 차수가_중복되는_모집회차가_있다면_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
 
             RecruitmentRound firstRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
@@ -177,8 +169,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void 모집_시작일과_종료일이_학기_시작일로부터_2주_이내에_있지_않다면_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
 
             RecruitmentRound firstRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
@@ -199,8 +190,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void RoundType_1차를_2차로_수정하려_하면_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
 
             RecruitmentRound firstRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
@@ -216,8 +206,7 @@ public class RecruitmentRoundValidatorTest {
         @Test
         void 모집_시작일이_지났다면_수정_실패한다() {
             // given
-            Recruitment recruitment =
-                    Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, ACADEMIC_YEAR, SEMESTER_TYPE);
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
 
             RecruitmentRound recruitmentRound =
                     RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentTest.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.global.common.constant.TemporalConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,10 @@ class RecruitmentTest {
 
             // when
             Recruitment recruitment = Recruitment.create(
-                    FEE_NAME, FEE, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), ACADEMIC_YEAR, SEMESTER_TYPE);
+                    FEE_NAME,
+                    FEE,
+                    Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE),
+                    Semester.of(ACADEMIC_YEAR, SEMESTER_TYPE));
 
             // then
             assertThat(recruitment.getSemesterPeriod().getStartDate()).isEqualTo(SEMESTER_START_DATE);

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/TemporalConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/TemporalConstant.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.global.common.constant;
 
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import java.time.LocalDateTime;
 
 public class TemporalConstant {
@@ -11,6 +12,7 @@ public class TemporalConstant {
     public static final SemesterType SEMESTER_TYPE = SemesterType.FIRST;
     public static final LocalDateTime SEMESTER_START_DATE = LocalDateTime.of(2024, 3, 2, 0, 0);
     public static final LocalDateTime SEMESTER_END_DATE = LocalDateTime.of(2024, 8, 31, 0, 0);
+    public static final Semester SEMESTER = Semester.of(ACADEMIC_YEAR, SEMESTER_TYPE);
 
     private TemporalConstant() {}
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -13,6 +13,7 @@ import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
 import com.gdschongik.gdsc.domain.coupon.domain.CouponType;
 import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
@@ -79,7 +80,10 @@ public class FixtureHelper {
             SemesterType semesterType,
             Money fee) {
         Recruitment recruitment = Recruitment.create(
-                FEE_NAME, fee, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), academicYear, semesterType);
+                FEE_NAME,
+                fee,
+                Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE),
+                Semester.of(academicYear, semesterType));
 
         return RecruitmentRound.create(
                 RECRUITMENT_ROUND_NAME, RoundType.FIRST, Period.of(startDate, endDate), recruitment);

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.*;
 import com.gdschongik.gdsc.domain.common.model.SemesterType;
 import com.gdschongik.gdsc.domain.common.vo.Money;
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.common.vo.Semester;
 import com.gdschongik.gdsc.domain.coupon.dao.CouponRepository;
 import com.gdschongik.gdsc.domain.coupon.dao.IssuedCouponRepository;
 import com.gdschongik.gdsc.domain.coupon.domain.Coupon;
@@ -227,7 +228,10 @@ public abstract class IntegrationTest {
 
     protected Recruitment createRecruitment(Integer academicYear, SemesterType semesterType, Money fee) {
         Recruitment recruitment = Recruitment.create(
-                FEE_NAME, fee, Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE), academicYear, semesterType);
+                FEE_NAME,
+                fee,
+                Period.of(SEMESTER_START_DATE, SEMESTER_END_DATE),
+                Semester.of(academicYear, semesterType));
         return recruitmentRepository.save(recruitment);
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #956
- close #803 
- close #774

## 📌 작업 내용 및 특이사항
- 기존 리팩토링 의도는 Semester 내부에 semester period 까지 담아서 관리하고 싶었는데, 외부에서 Semester 를 다룰 때 (연도, 학기) 조합으로 다루는 경우가 많다보니 구체적인 period 까지 담으면 오히려 불편할 것 같았습니다.
- 그래서 period 는 기존 처럼 recruitment 엔티티가 갖고 있는 대신, 이전 이슈로도 있었던 recruitment round 에서 semester 를 없애는 리팩토링을 진행하였습니다.

## 📝 참고사항
-

## 📚 기타
-
