### PR TITLE
feat: support third recruitment round

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RoundType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RoundType.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RoundType {
     FIRST("1차"),
-    SECOND("2차");
+    SECOND("2차"),
+    THIRD("3차");
 
     private final String value;
 
@@ -17,5 +18,9 @@ public enum RoundType {
 
     public boolean isSecond() {
         return this == SECOND;
+    }
+
+    public boolean isThird() {
+        return this == THIRD;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/service/RecruitmentRoundValidator.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/service/RecruitmentRoundValidator.java
@@ -44,7 +44,7 @@ public class RecruitmentRoundValidator {
         validatePeriodWithinTwoWeeks(startDate, endDate, currentRecruitmentRound.getRecruitment());
         validatePeriodOverlap(otherRecruitmentRounds, startDate, endDate);
         validateRoundOverlap(otherRecruitmentRounds, roundType);
-        validateRoundOneToTwo(currentRecruitmentRound.getRoundType(), roundType);
+        validateFirstRoundModification(currentRecruitmentRound.getRoundType(), roundType);
         currentRecruitmentRound.validatePeriodNotStarted(now);
     }
 
@@ -78,16 +78,17 @@ public class RecruitmentRoundValidator {
                 });
     }
 
-    // 1차 모집이 없는데 2차 모집을 생성하려고 하는 경우
+    // 1차 모집이 없는데 2차 또는 3차 모집을 생성하려고 하는 경우
     private void validateRoundOneExist(List<RecruitmentRound> recruitmentRounds, RoundType roundType) {
-        if (roundType.isSecond() && recruitmentRounds.stream().noneMatch(RecruitmentRound::isFirstRound)) {
+        if ((roundType.isSecond() || roundType.isThird())
+                && recruitmentRounds.stream().noneMatch(RecruitmentRound::isFirstRound)) {
             throw new CustomException(ROUND_ONE_DOES_NOT_EXIST);
         }
     }
 
-    // 1차 모집을 비워둬서는 안되므로, 1차 모집을 2차 모집으로 수정하려고 하는 경우 예외 발생
-    private void validateRoundOneToTwo(RoundType previousRoundType, RoundType newRoundType) {
-        if (previousRoundType.isFirst() && newRoundType.isSecond()) {
+    // 1차 모집을 비워둬서는 안되므로, 1차 모집을 다른 차수로 수정하려고 하는 경우 예외 발생
+    private void validateFirstRoundModification(RoundType previousRoundType, RoundType newRoundType) {
+        if (previousRoundType.isFirst() && (newRoundType.isSecond() || newRoundType.isThird())) {
             throw new CustomException(ROUND_ONE_DOES_NOT_EXIST);
         }
     }

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -98,6 +98,18 @@ public class RecruitmentRoundValidatorTest {
         }
 
         @Test
+        void RoundType_1차가_없을때_3차를_생성하려_하면_실패한다() {
+            // given
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
+
+            // when & then
+            assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundCreate(
+                            ROUND_THREE_START_DATE, ROUND_THREE_END_DATE, RoundType.THIRD, recruitment, List.of()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ROUND_ONE_DOES_NOT_EXIST.getMessage());
+        }
+
+        @Test
         void 기간이_중복되는_모집회차가_있다면_실패한다() {
             // given
             Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
@@ -199,6 +211,22 @@ public class RecruitmentRoundValidatorTest {
             // when & then
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundUpdate(
                             START_DATE, END_DATE, LocalDateTime.now(), RoundType.SECOND, firstRound, List.of()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ROUND_ONE_DOES_NOT_EXIST.getMessage());
+        }
+
+        @Test
+        void RoundType_1차를_3차로_수정하려_하면_실패한다() {
+            // given
+            Recruitment recruitment = Recruitment.create(FEE_NAME, FEE, START_TO_END_PERIOD, SEMESTER);
+
+            RecruitmentRound firstRound =
+                    RecruitmentRound.create(RECRUITMENT_ROUND_NAME, ROUND_TYPE, START_TO_END_PERIOD, recruitment);
+            ReflectionTestUtils.setField(firstRound, "id", 1L);
+
+            // when & then
+            assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundUpdate(
+                            START_DATE, END_DATE, LocalDateTime.now(), RoundType.THIRD, firstRound, List.of()))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ROUND_ONE_DOES_NOT_EXIST.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/RecruitmentConstant.java
@@ -26,5 +26,12 @@ public class RecruitmentConstant {
     public static final LocalDateTime ROUND_TWO_END_DATE = LocalDateTime.of(2024, 3, 10, 0, 0);
     public static final Period ROUND_TWO_START_TO_END_PERIOD = Period.of(ROUND_TWO_START_DATE, ROUND_TWO_END_DATE);
 
+    // 3차 모집 상수
+    public static final String ROUND_THREE_RECRUITMENT_NAME = "2024학년도 1학기 3차 모집";
+    public static final LocalDateTime ROUND_THREE_START_DATE = LocalDateTime.of(2024, 3, 15, 0, 0);
+    public static final LocalDateTime ROUND_THREE_END_DATE = LocalDateTime.of(2024, 3, 16, 0, 0);
+    public static final Period ROUND_THREE_START_TO_END_PERIOD =
+            Period.of(ROUND_THREE_START_DATE, ROUND_THREE_END_DATE);
+
     private RecruitmentConstant() {}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- {issue-close-placeholder-do-not-modify}

## 📌 작업 내용 및 특이사항
- RoundType enum에 THIRD 추가 및 검증 로직 확장
- `RecruitmentRoundValidator`에서 1차 모집 수정 검증 메서드 이름 변경
- 3차 모집 상수와 검증 테스트 케이스 포함
- 테스트용 README 파일 삭제

## 📝 참고사항
-

## 📚 기타
-

------
https://chatgpt.com/codex/tasks/task_e_684a2d3b9848832fb8a616d76b6a91be