### PR TITLE
fix: 정회원 승급 커맨드 작동하지 않는 문제

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/member/dao/MemberCustomRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.gdschongik.gdsc.domain.member.dao;
 import static com.gdschongik.gdsc.domain.common.model.RequirementStatus.*;
 import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
 import static com.gdschongik.gdsc.domain.membership.domain.QMembership.*;
+import static com.gdschongik.gdsc.domain.recruitment.domain.QRecruitment.*;
+import static com.gdschongik.gdsc.domain.recruitment.domain.QRecruitmentRound.*;
 
 import com.gdschongik.gdsc.domain.common.model.RequirementStatus;
 import com.gdschongik.gdsc.domain.common.vo.Semester;
@@ -64,6 +66,10 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository, Membe
                 .selectFrom(member)
                 .leftJoin(membership)
                 .on(membership.member.eq(member))
+                .leftJoin(recruitmentRound)
+                .on(membership.recruitmentRound.eq(recruitmentRound))
+                .leftJoin(recruitment)
+                .on(recruitmentRound.recruitment.eq(recruitment))
                 .where(
                         eqRole(MemberRole.ASSOCIATE),
                         eqSemester(semester),
@@ -93,14 +99,11 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository, Membe
 
     private BooleanExpression eqSemester(Semester semester) {
         return semester != null
-                ? membership
-                        .recruitmentRound
-                        .recruitment
+                ? recruitment
                         .semester
                         .academicYear
                         .eq(semester.getAcademicYear())
-                        .and(membership.recruitmentRound.recruitment.semester.semesterType.eq(
-                                semester.getSemesterType()))
+                        .and(recruitment.semester.semesterType.eq(semester.getSemesterType()))
                 : null;
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- {issue-close-placeholder-do-not-modify}

## 📌 작업 내용 및 특이사항
- 쿼리의 경로가 `membership.recruitmentRound.recruitment`으로 길어지다보니 문제가 생겼습니다.
이번에 처음 알았는데 [쿼리 경로는 2레벨까지만 초기화](http://querydsl.com/static/querydsl/4.0.1/reference/ko-KR/html/ch03s03.html)된다고 하네요.
- QueryInit을 사용하거나 조인을 사용하는 방법이 있는데 조인을 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-
