### PR TITLE
feat: `Period` VO의 모든 필드가 존재하도록 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
@@ -57,12 +57,6 @@ public final class Period {
         }
     }
 
-    public void validatePeriodDateIsNotNull() {
-        if (startDate == null || endDate == null) {
-            throw new CustomException(PERIOD_DATE_NOT_NULL);
-        }
-    }
-
     /**
      * 현재 시간이 기간 내에 있는지 확인합니다.
      * 시작일시는 포함하고 종료일시는 포함하지 않습니다.

--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
@@ -34,6 +34,10 @@ public final class Period {
     }
 
     private static void validatePeriod(LocalDateTime startDate, LocalDateTime endDate) {
+        if (startDate == null || endDate == null) {
+            throw new CustomException(PERIOD_DATE_NOT_NULL);
+        }
+
         if (startDate.isAfter(endDate) || startDate.isEqual(endDate)) {
             throw new CustomException(DATE_PRECEDENCE_INVALID);
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
@@ -53,20 +53,17 @@ public final class Period {
         }
     }
 
+    public void validatePeriodDateIsNotNull() {
+        if (startDate == null || endDate == null) {
+            throw new CustomException(PERIOD_DATE_NOT_NULL);
+        }
+    }
+
     /**
      * 현재 시간이 기간 내에 있는지 확인합니다.
      * 시작일시는 포함하고 종료일시는 포함하지 않습니다.
      */
     public boolean isWithin(LocalDateTime now) {
         return now.isAfter(startDate) && now.isBefore(endDate) || now.isEqual(startDate);
-    }
-
-    /**
-     * Period 객체가 비어있는지 확인합니다.
-     * 시작/종료일자가 하나라도 없으면 비어있다고 간주합니다.
-     */
-    @JsonIgnore
-    public boolean isEmpty() {
-        return startDate == null || endDate == null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
@@ -35,9 +35,9 @@ public enum AssignmentHistoryStatus {
             return BEFORE_SUBMISSION;
         }
 
-        Period assignmentPeriod = studySession.getAssignmentPeriod();
-
         validateCommittedAtWithinAssignmentPeriod(assignmentHistory, studySession);
+
+        Period assignmentPeriod = studySession.getAssignmentPeriod();
 
         if (now.isBefore(assignmentPeriod.getStartDate())) {
             return BEFORE_SUBMISSION;

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
@@ -37,7 +37,6 @@ public enum AssignmentHistoryStatus {
 
         Period assignmentPeriod = studySession.getAssignmentPeriod();
 
-        assignmentPeriod.validatePeriodDateIsNotNull();
         validateCommittedAtWithinAssignmentPeriod(assignmentHistory, studySession);
 
         if (now.isBefore(assignmentPeriod.getStartDate())) {

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryStatus.java
@@ -31,14 +31,14 @@ public enum AssignmentHistoryStatus {
             throws CustomException {
 
         // 제출기한이 설정되지 않았을 경우
-        if (studySession.getAssignmentPeriod() == null
-                || studySession.getAssignmentPeriod().isEmpty()) {
+        if (studySession.getAssignmentPeriod() == null) {
             return BEFORE_SUBMISSION;
         }
 
-        validateCommittedAtWithinAssignmentPeriod(assignmentHistory, studySession);
-
         Period assignmentPeriod = studySession.getAssignmentPeriod();
+
+        assignmentPeriod.validatePeriodDateIsNotNull();
+        validateCommittedAtWithinAssignmentPeriod(assignmentHistory, studySession);
 
         if (now.isBefore(assignmentPeriod.getStartDate())) {
             return BEFORE_SUBMISSION;

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
@@ -25,7 +25,7 @@ public enum AttendanceStatus {
 
         Period lessonPeriod = studySession.getLessonPeriod();
 
-        if (lessonPeriod.isEmpty() || lessonPeriod.getStartDate().isAfter(now)) {
+        if (lessonPeriod == null || lessonPeriod.getStartDate().isAfter(now)) {
             return BEFORE_ATTENDANCE;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
@@ -25,13 +25,7 @@ public enum AttendanceStatus {
 
         Period lessonPeriod = studySession.getLessonPeriod();
 
-        if (lessonPeriod == null) {
-            return BEFORE_ATTENDANCE;
-        }
-
-        lessonPeriod.validatePeriodDateIsNotNull();
-
-        if (lessonPeriod.getStartDate().isAfter(now)) {
+        if (lessonPeriod == null || lessonPeriod.getStartDate().isAfter(now)) {
             return BEFORE_ATTENDANCE;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AttendanceStatus.java
@@ -25,7 +25,13 @@ public enum AttendanceStatus {
 
         Period lessonPeriod = studySession.getLessonPeriod();
 
-        if (lessonPeriod == null || lessonPeriod.getStartDate().isAfter(now)) {
+        if (lessonPeriod == null) {
+            return BEFORE_ATTENDANCE;
+        }
+
+        lessonPeriod.validatePeriodDateIsNotNull();
+
+        if (lessonPeriod.getStartDate().isAfter(now)) {
             return BEFORE_ATTENDANCE;
         }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -116,9 +116,11 @@ public class StudySessionV2 extends BaseEntity {
     // 데이터 전달 로직
 
     public void validateAssignmentSubmittable(LocalDateTime now) {
-        if (assignmentPeriod == null || assignmentPeriod.isEmpty()) {
+        if (assignmentPeriod == null) {
             throw new CustomException(ASSIGNMENT_SUBMIT_NOT_PUBLISHED);
         }
+
+        assignmentPeriod.validatePeriodDateIsNotNull();
 
         if (now.isBefore(assignmentPeriod.getStartDate())) {
             throw new CustomException(ASSIGNMENT_SUBMIT_NOT_STARTED);
@@ -130,17 +132,21 @@ public class StudySessionV2 extends BaseEntity {
     }
 
     public boolean isAssignmentSubmittable(LocalDateTime now) {
-        if (assignmentPeriod == null || assignmentPeriod.isEmpty()) {
+        if (assignmentPeriod == null) {
             return false;
         }
+
+        assignmentPeriod.validatePeriodDateIsNotNull();
 
         return assignmentPeriod.isWithin(now);
     }
 
     public boolean isAttendable(LocalDateTime now) {
-        if (lessonPeriod == null || lessonPeriod.isEmpty()) {
+        if (lessonPeriod == null) {
             return false;
         }
+
+        lessonPeriod.validatePeriodDateIsNotNull();
 
         return lessonPeriod.isWithin(now);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudySessionV2.java
@@ -120,8 +120,6 @@ public class StudySessionV2 extends BaseEntity {
             throw new CustomException(ASSIGNMENT_SUBMIT_NOT_PUBLISHED);
         }
 
-        assignmentPeriod.validatePeriodDateIsNotNull();
-
         if (now.isBefore(assignmentPeriod.getStartDate())) {
             throw new CustomException(ASSIGNMENT_SUBMIT_NOT_STARTED);
         }
@@ -136,8 +134,6 @@ public class StudySessionV2 extends BaseEntity {
             return false;
         }
 
-        assignmentPeriod.validatePeriodDateIsNotNull();
-
         return assignmentPeriod.isWithin(now);
     }
 
@@ -145,8 +141,6 @@ public class StudySessionV2 extends BaseEntity {
         if (lessonPeriod == null) {
             return false;
         }
-
-        lessonPeriod.validatePeriodDateIsNotNull();
 
         return lessonPeriod.isWithin(now);
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -266,9 +266,11 @@ public class StudyV2 extends BaseEntity {
             Period currentLessonPeriod = session.getLessonPeriod();
 
             // lessonPeriod가 null인 경우 검증 제외
-            if (currentLessonPeriod == null || currentLessonPeriod.isEmpty()) {
+            if (currentLessonPeriod == null) {
                 continue;
             }
+
+            currentLessonPeriod.validatePeriodDateIsNotNull();
 
             LocalDateTime currentStartDate = currentLessonPeriod.getStartDate();
 

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/StudyV2.java
@@ -270,8 +270,6 @@ public class StudyV2 extends BaseEntity {
                 continue;
             }
 
-            currentLessonPeriod.validatePeriodDateIsNotNull();
-
             LocalDateTime currentStartDate = currentLessonPeriod.getStartDate();
 
             // 이전 시작일이 존재하고, 현재 시작일이 이전 시작일보다 과거이거나 같은 경우 실패

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 
     // Period
     PERIOD_OVERLAP(CONFLICT, "기간이 중복됩니다."),
+    PERIOD_DATE_NOT_NULL(BAD_REQUEST, "시작일, 종료일은 null이 될 수 없습니다."),
 
     // Member
     MEMBER_NOT_FOUND(NOT_FOUND, "존재하지 않는 커뮤니티 멤버입니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1042

## 📌 작업 내용 및 특이사항
- Period VO 가 모두 비어있지 않도록 검증 메서드를 작성했습니다.

## 📝 참고사항
- Period VO 필드가 모두 비어있으면 Period 자체가 null 로 반환되므로, 시작일, 종료일이 모두 null 인 상황은 Period 객체가 null 인지 검증하는 것으로 확인 가능하며, 두 필드 중 하나만 비어있는 경우는 올바르지 않은 상황이므로 에러가 발생하는 것이 맞습니다.

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 기간의 시작일 또는 종료일이 null인 경우 예외가 발생하도록 검증 기능이 추가되었습니다.
    - "시작일, 종료일은 null이 될 수 없습니다."라는 새로운 오류 코드가 도입되었습니다.

- **Bug Fixes**
    - 기간 관련 검증 로직이 개선되어, null 값에 대한 처리가 보다 명확해졌습니다.

- **Refactor**
    - 기간 객체의 유효성 검사 방식이 변경되어, 내부 날짜 값의 null 여부를 명확히 확인하도록 수정되었습니다.
    - 기간의 빈 상태를 확인하는 메서드가 제거되고, null 체크 중심으로 로직이 간소화되었습니다.
    - 과제 및 출석 관련 기간 검증 로직에서 빈 기간 체크가 제거되고 null 체크로 통일되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->