### PR TITLE
feat: 이벤트 도메인 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
@@ -1,0 +1,85 @@
+package com.gdschongik.gdsc.domain.event.domain;
+
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    EventType type;
+
+    @Comment("행사 이름")
+    String name;
+
+    @Comment("행사 설명")
+    @Column(columnDefinition = "TEXT")
+    String description;
+
+    @Comment("행사 기간")
+    @Embedded
+    @AttributeOverride(name = "startDate", column = @Column(name = "event_start_at"))
+    @AttributeOverride(name = "endDate", column = @Column(name = "event_end_at"))
+    Period eventPeriod;
+
+    @Comment("RSVP 활성화 여부")
+    @Enumerated(EnumType.STRING)
+    UsageStatus rsvp;
+
+    @Comment("뒤풀이 활성화 여부")
+    @Enumerated(EnumType.STRING)
+    UsageStatus afterParty;
+
+    @Comment("선입금 활성화 여부")
+    @Enumerated(EnumType.STRING)
+    UsageStatus prePayment;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Event(
+            EventType type,
+            String name,
+            String description,
+            Period eventPeriod,
+            UsageStatus rsvp,
+            UsageStatus afterParty,
+            UsageStatus prePayment) {
+        this.type = type;
+        this.name = name;
+        this.description = description;
+        this.eventPeriod = eventPeriod;
+        this.rsvp = rsvp;
+        this.afterParty = afterParty;
+        this.prePayment = prePayment;
+    }
+
+    public static Event create(
+            EventType type,
+            String name,
+            String description,
+            Period eventPeriod,
+            UsageStatus rsvp,
+            UsageStatus afterParty,
+            UsageStatus prePayment) {
+        return Event.builder()
+                .type(type)
+                .name(name)
+                .description(description)
+                .eventPeriod(eventPeriod)
+                .rsvp(rsvp)
+                .afterParty(afterParty)
+                .prePayment(prePayment)
+                .build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
@@ -19,46 +19,46 @@ public class Event {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    EventType type;
+    private EventType type;
 
     @Comment("행사 이름")
-    String name;
+    private String name;
 
     @Comment("행사 설명")
     @Column(columnDefinition = "TEXT")
-    String description;
+    private String description;
 
     @Comment("행사 기간")
     @Embedded
     @AttributeOverride(name = "startDate", column = @Column(name = "event_start_at"))
     @AttributeOverride(name = "endDate", column = @Column(name = "event_end_at"))
-    Period eventPeriod;
+    private Period period;
 
     @Comment("RSVP 활성화 여부")
     @Enumerated(EnumType.STRING)
-    UsageStatus rsvp;
+    private UsageStatus rsvp;
 
     @Comment("뒤풀이 활성화 여부")
     @Enumerated(EnumType.STRING)
-    UsageStatus afterParty;
+    private UsageStatus afterParty;
 
     @Comment("선입금 활성화 여부")
     @Enumerated(EnumType.STRING)
-    UsageStatus prePayment;
+    private UsageStatus prePayment;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Event(
             EventType type,
             String name,
             String description,
-            Period eventPeriod,
+            Period period,
             UsageStatus rsvp,
             UsageStatus afterParty,
             UsageStatus prePayment) {
         this.type = type;
         this.name = name;
         this.description = description;
-        this.eventPeriod = eventPeriod;
+        this.period = period;
         this.rsvp = rsvp;
         this.afterParty = afterParty;
         this.prePayment = prePayment;
@@ -68,7 +68,7 @@ public class Event {
             EventType type,
             String name,
             String description,
-            Period eventPeriod,
+            Period period,
             UsageStatus rsvp,
             UsageStatus afterParty,
             UsageStatus prePayment) {
@@ -76,7 +76,7 @@ public class Event {
                 .type(type)
                 .name(name)
                 .description(description)
-                .eventPeriod(eventPeriod)
+                .period(period)
                 .rsvp(rsvp)
                 .afterParty(afterParty)
                 .prePayment(prePayment)

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventType.java
@@ -1,0 +1,14 @@
+package com.gdschongik.gdsc.domain.event.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EventType {
+    ONLINE("온라인 행사"),
+    OFFLINE("오프라인 행사"),
+    ;
+
+    private final String value;
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventType.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.event.domain;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventType.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventType.java
@@ -2,9 +2,10 @@ package com.gdschongik.gdsc.domain.event.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public enum EventType {
     ONLINE("온라인 행사"),
     OFFLINE("오프라인 행사"),

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/UsageStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/UsageStatus.java
@@ -2,9 +2,10 @@ package com.gdschongik.gdsc.domain.event.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public enum UsageStatus {
     ENABLED("활성화"),
     DISABLED("비활성화");

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/UsageStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/UsageStatus.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.event.domain;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/UsageStatus.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/UsageStatus.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.event.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UsageStatus {
+    ENABLED("활성화"),
+    DISABLED("비활성화");
+
+    private final String value;
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1098

## 📌 작업 내용 및 특이사항
현재까지 나온 기능 요구사항에 맞춰 행사 도메인 엔티티를 구현했습니다.
- 1차 MVP에선 정적 레이아웃을 사용, 형식화된 몇몇 질문을 on/off 형식으로 사용 여부 결정
- 행사 기본 정보 : 행사 이름, 온오프라인 여부, 행사 기간, 행사 설명

- 행사 참여 신청시 필요한 정보
  - 필수 : (참여자 이름, 전화번호, 학번, 유의사항 확인 여부)
  - 선택 : (RSVP 사용 여부, 뒤풀이 존재 여부, 선입금 필요 여부)
  - 선택 필드만 행사 엔티티에 저장하도록 구현했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 정보를 나타내는 새로운 엔터티가 추가되었습니다.
  * 온라인/오프라인 유형을 구분하는 이벤트 타입이 도입되었습니다.
  * RSVP, 애프터파티, 사전결제 기능의 활성화 여부를 관리하는 상태가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->