### PR TITLE
feat: 회원, 비회원 뒤풀이 현장등록 로직 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainService.java
@@ -60,6 +60,30 @@ public class EventParticipationDomainService {
                 event);
     }
 
+    /**
+     * 회원이 현장등록을 통해 뒤풀이에 참여 신청하는 메서드입니다.
+     */
+    public EventParticipation joinOnsiteForRegistered(Member member, Event event) {
+        validateMemberWhenOnlyRegularRoleAllowed(event, member);
+
+        PaymentStatus prePaymentStatus = PaymentStatus.getInitialPrePaymentStatus(event);
+        PaymentStatus postPaymentStatus = PaymentStatus.getInitialPostPaymentStatus(event);
+
+        return EventParticipation.createOnsiteForRegistered(member, prePaymentStatus, postPaymentStatus, event);
+    }
+
+    /**
+     * 비회원이 현장등록을 통해 뒤풀이에 참여 신청하는 메서드입니다.
+     */
+    public EventParticipation joinOnsiteForUnregistered(Participant participant, Event event) {
+        validateNotRegularRoleAllowed(event);
+
+        PaymentStatus prePaymentStatus = PaymentStatus.getInitialPrePaymentStatus(event);
+        PaymentStatus postPaymentStatus = PaymentStatus.getInitialPostPaymentStatus(event);
+
+        return EventParticipation.createOnsiteForUnregistered(participant, prePaymentStatus, postPaymentStatus, event);
+    }
+
     // 검증 로직
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainService.java
@@ -16,7 +16,6 @@ public class EventParticipationDomainService {
      */
     public EventParticipation applyEventForRegistered(
             Member member, AfterPartyApplicationStatus afterPartyApplicationStatus, Event event, LocalDateTime now) {
-
         validateEventApplicationPeriod(event, now);
         validateMemberWhenOnlyRegularRoleAllowed(event, member);
         validateAfterPartyApplicationStatus(event, afterPartyApplicationStatus);
@@ -42,7 +41,6 @@ public class EventParticipationDomainService {
             AfterPartyApplicationStatus afterPartyApplicationStatus,
             Event event,
             LocalDateTime now) {
-
         validateEventApplicationPeriod(event, now);
         validateNotRegularRoleAllowed(event);
         validateAfterPartyApplicationStatus(event, afterPartyApplicationStatus);
@@ -98,6 +96,21 @@ public class EventParticipationDomainService {
     }
 
     /**
+     * 뒤풀이 신청 상태를 검증하는 메서드입니다.
+     * 온라인 신청에서만 사용됩니다.
+     */
+    private void validateAfterPartyApplicationStatus(
+            Event event, AfterPartyApplicationStatus afterPartyApplicationStatus) {
+        if (event.getAfterPartyStatus().isEnabled() && afterPartyApplicationStatus.isNone()) {
+            throw new CustomException(EVENT_NOT_APPLIABLE_AFTER_PARTY_NONE);
+        }
+
+        if (!event.getAfterPartyStatus().isEnabled() && !afterPartyApplicationStatus.isNone()) {
+            throw new CustomException(EVENT_NOT_APPLIABLE_AFTER_PARTY_NOT_NONE);
+        }
+    }
+
+    /**
      * 정회원만 허용되는 이벤트일 경우, 회원의 역할을 검증하는 메서드입니다.
      * 회원 신청시에만 사용됩니다.
      */
@@ -116,22 +129,4 @@ public class EventParticipationDomainService {
             throw new CustomException(EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE);
         }
     }
-
-    /**
-     * 뒤풀이 신청 상태를 검증하는 메서드입니다.
-     * 모든 이벤트 참여 신청에서 사용됩니다.
-     */
-    private void validateAfterPartyApplicationStatus(
-            Event event, AfterPartyApplicationStatus afterPartyApplicationStatus) {
-        if (event.getAfterPartyStatus().isEnabled() && afterPartyApplicationStatus.isNone()) {
-            throw new CustomException(EVENT_NOT_APPLIABLE_AFTER_PARTY_NONE);
-        }
-
-        if (!event.getAfterPartyStatus().isEnabled() && !afterPartyApplicationStatus.isNone()) {
-            throw new CustomException(EVENT_NOT_APPLIABLE_AFTER_PARTY_NOT_NONE);
-        }
-    }
-
-    // TODO: joinOnsiteForRegistered, joinOnsiteForUnregistered 메서드 구현
-    // TODO: 작업 분량이 많기에 메서드 하나씩 구현할 것
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -18,7 +18,7 @@ public class EventParticipationDomainServiceTest {
     FixtureHelper fixtureHelper = new FixtureHelper();
 
     @Nested
-    class 가입된_유저가_온라인으로_신청하는_경우 {
+    class 회원이_온라인으로_신청하는_경우 {
 
         @Test
         void 신청_기간이_아닌경우_실패한다() {
@@ -184,6 +184,50 @@ public class EventParticipationDomainServiceTest {
             assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, appliedStatus, event, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLIABLE_AFTER_PARTY_NOT_NONE.getMessage());
+        }
+    }
+
+    @Nested
+    class 회원이_뒤풀이_현장등록으로_신청하는_경우 {
+
+        @Test
+        void 정회원만_참석_가능한_행사에_정회원이_아닌_유저가_신청하면_실패한다() {
+            // given
+            Member guestMember = fixtureHelper.createGuestMember(1L);
+            Event event = fixtureHelper.createEvent(
+                    1L,
+                    UsageStatus.ENABLED, // 정회원 전용 신청 폼
+                    AFTER_PARTY_STATUS,
+                    PRE_PAYMENT_STATUS,
+                    POST_PAYMENT_STATUS,
+                    RSVP_QUESTION_STATUS);
+
+            // when & then
+            assertThatThrownBy(() -> domainService.joinOnsiteForRegistered(guestMember, event))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE.getMessage());
+        }
+    }
+
+    @Nested
+    class 비회원이_뒤풀이_현장등록으로_신청하는_경우 {
+
+        @Test
+        void 정회원만_참석_가능한_행사에_신청하면_실패한다() {
+            // given
+            Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
+            Event event = fixtureHelper.createEvent(
+                    1L,
+                    UsageStatus.ENABLED, // 정회원 전용 신청 폼
+                    AFTER_PARTY_STATUS,
+                    PRE_PAYMENT_STATUS,
+                    POST_PAYMENT_STATUS,
+                    RSVP_QUESTION_STATUS);
+
+            // when & then
+            assertThatThrownBy(() -> domainService.joinOnsiteForUnregistered(participant, event))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(EVENT_NOT_APPLIABLE_NOT_REGULAR_ROLE.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1120
- close #1121

## 📌 작업 내용 및 특이사항
- 분량이 짧아서 이슈 2개 같이 구현했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원 및 비회원의 뒤풀이 현장 등록 기능이 추가되었습니다.

* **버그 수정**
  * 중복된 내부 검증 로직이 정리되어 안정성이 향상되었습니다.

* **테스트**
  * 회원 및 비회원의 현장 등록 시 역할 기반 접근 제한에 대한 테스트가 추가되었습니다.
  * 기존 온라인 신청 관련 테스트 클래스 명칭이 더 명확하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->