### PR TITLE
feat: 이벤트 신청 정보 삭제 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
@@ -1,0 +1,23 @@
+package com.gdschongik.gdsc.domain.event.api;
+
+import com.gdschongik.gdsc.domain.event.dto.request.EventParticipationDeleteRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Event Participation - Admin", description = "어드민 행사 신청 관리 API입니다.")
+@RestController
+@RequestMapping("/admin/event-participations")
+@RequiredArgsConstructor
+public class AdminEventParticipationController {
+
+    @Operation(summary = "행사 신청 정보 삭제", description = "행사 신청 정보를 삭제합니다.")
+    @DeleteMapping
+    public ResponseEntity<Void> deleteEventParticipations(@Valid @RequestBody EventParticipationDeleteRequest request) {
+        // TODO: 서비스 로직 구현
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventParticipationDeleteRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventParticipationDeleteRequest.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.event.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record EventParticipationDeleteRequest(@NotEmpty List<Long> eventParticipationIds) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- {issue-close-placeholder-do-not-modify}

## 📌 작업 내용 및 특이사항

<img width="788" height="754" alt="스크린샷 2025-08-12 오후 10 54 52" src="https://github.com/user-attachments/assets/c5bce262-5e0f-4bf6-8f5b-7e845f6964d4" />

- 행사 신청 정보 삭제 API 입니다.
- 어드민만 사용 가능하기 때문에 AdminController를 생성했습니다.
- 플로우 상 다건 삭제가 가능해야 하기 때문에 List<Long> 입력을 받습니다.

## 📝 참고사항
-

## 📚 기타
-
