### PR TITLE
feat: 이벤트 뒤풀이 인원 조회 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
@@ -4,9 +4,10 @@ import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus;
 import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.PaymentStatus;
+import com.gdschongik.gdsc.domain.event.dto.EventParticipationDto;
+import com.gdschongik.gdsc.domain.event.dto.ParticipantDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipationDeleteRequest;
-import com.gdschongik.gdsc.domain.event.dto.response.AfterPartyParticipationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,17 +35,15 @@ public class AdminEventParticipationController {
 
     @Operation(summary = "뒤풀이 신청 정보 조회", description = "뒤풀이 신청 정보를 조회합니다.")
     @GetMapping("/after-party")
-    public ResponseEntity<Page<AfterPartyParticipationResponse>> getAfterPartyParticipations(
+    public ResponseEntity<Page<EventParticipationDto>> getAfterPartyParticipations(
             @RequestParam(name = "eventId") Long eventId,
             @ParameterObject EventParticipantQueryOption queryOption,
             @ParameterObject Pageable pageable) {
 
         // TODO: 임시 응답 제거 후 서비스 로직 구현
-        var exampleContent = List.of(new AfterPartyParticipationResponse(
+        var exampleContent = List.of(new EventParticipationDto(
                 1L,
-                "김홍익",
-                "C123456",
-                "010-1234-5678",
+                new ParticipantDto("김홍익", "C123456", "010-1234-5678"),
                 1L,
                 MainEventApplicationStatus.APPLIED,
                 AfterPartyApplicationStatus.APPLIED,

--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
@@ -1,10 +1,21 @@
 package com.gdschongik.gdsc.domain.event.api;
 
+import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
+import com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus;
+import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
+import com.gdschongik.gdsc.domain.event.domain.PaymentStatus;
+import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipationDeleteRequest;
+import com.gdschongik.gdsc.domain.event.dto.response.AfterPartyParticipationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,5 +30,29 @@ public class AdminEventParticipationController {
     public ResponseEntity<Void> deleteEventParticipations(@Valid @RequestBody EventParticipationDeleteRequest request) {
         // TODO: 서비스 로직 구현
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "뒤풀이 신청 정보 조회", description = "뒤풀이 신청 정보를 조회합니다.")
+    @GetMapping("/after-party")
+    public ResponseEntity<Page<AfterPartyParticipationResponse>> getAfterPartyParticipations(
+            @RequestParam(name = "eventId") Long eventId,
+            @ParameterObject EventParticipantQueryOption queryOption,
+            @ParameterObject Pageable pageable) {
+
+        // TODO: 임시 응답 제거 후 서비스 로직 구현
+        var exampleContent = List.of(new AfterPartyParticipationResponse(
+                1L,
+                "김홍익",
+                "C123456",
+                "010-1234-5678",
+                1L,
+                MainEventApplicationStatus.APPLIED,
+                AfterPartyApplicationStatus.APPLIED,
+                AfterPartyAttendanceStatus.NOT_ATTENDED,
+                PaymentStatus.UNPAID,
+                PaymentStatus.UNPAID));
+
+        var exampleResponse = new PageImpl<>(exampleContent, pageable, 1L);
+        return ResponseEntity.ok(exampleResponse);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
@@ -36,14 +36,14 @@ public class AdminEventParticipationController {
     @Operation(summary = "뒤풀이 신청 정보 조회", description = "뒤풀이 신청 정보를 조회합니다.")
     @GetMapping("/after-party")
     public ResponseEntity<Page<EventParticipationDto>> getAfterPartyParticipations(
-            @RequestParam(name = "eventId") Long eventId,
+            @RequestParam(name = "event") Long eventId,
             @ParameterObject EventParticipantQueryOption queryOption,
             @ParameterObject Pageable pageable) {
 
         // TODO: 임시 응답 제거 후 서비스 로직 구현
         var exampleContent = List.of(new EventParticipationDto(
                 1L,
-                new ParticipantDto("김홍익", "C123456", "010-1234-5678"),
+                new ParticipantDto("김홍익", "C123456", "01012345678"),
                 1L,
                 MainEventApplicationStatus.APPLIED,
                 AfterPartyApplicationStatus.APPLIED,

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/EventParticipationDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/EventParticipationDto.java
@@ -1,15 +1,13 @@
-package com.gdschongik.gdsc.domain.event.dto.response;
+package com.gdschongik.gdsc.domain.event.dto;
 
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus;
 import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.PaymentStatus;
 
-public record AfterPartyParticipationResponse(
+public record EventParticipationDto(
         Long eventParticipationId,
-        String participantName,
-        String participantStudentId,
-        String participantPhone,
+        ParticipantDto participant,
         Long memberId,
         MainEventApplicationStatus mainEventApplicationStatus,
         AfterPartyApplicationStatus afterPartyApplicationStatus,

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/ParticipantDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/ParticipantDto.java
@@ -1,0 +1,3 @@
+package com.gdschongik.gdsc.domain.event.dto;
+
+public record ParticipantDto(String name, String studentId, String phone) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventParticipantQueryOption.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventParticipantQueryOption.java
@@ -1,0 +1,8 @@
+package com.gdschongik.gdsc.domain.event.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record EventParticipantQueryOption(
+        @Schema(description = "이름") String name,
+        @Schema(description = "학번") String studentId,
+        @Schema(description = "전화번호") String phone) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/response/AfterPartyParticipationResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/response/AfterPartyParticipationResponse.java
@@ -1,0 +1,18 @@
+package com.gdschongik.gdsc.domain.event.dto.response;
+
+import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
+import com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus;
+import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
+import com.gdschongik.gdsc.domain.event.domain.PaymentStatus;
+
+public record AfterPartyParticipationResponse(
+        Long eventParticipationId,
+        String participantName,
+        String participantStudentId,
+        String participantPhone,
+        Long memberId,
+        MainEventApplicationStatus mainEventApplicationStatus,
+        AfterPartyApplicationStatus afterPartyApplicationStatus,
+        AfterPartyAttendanceStatus afterPartyAttendanceStatus,
+        PaymentStatus prePaymentStatus,
+        PaymentStatus postPaymentStatus) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1125

## 📌 작업 내용 및 특이사항
[뒤풀이 신청 정보 조회]
<img width="791" height="746" alt="스크린샷 2025-08-14 오후 10 27 38" src="https://github.com/user-attachments/assets/850c573c-617a-48ff-b780-78c20e3eea1c" />

- 뒤풀이 신청 정보 조회 API를 추가했습니다.
- 메인 행사 신청 인원 화면에선 디스코드 닉네임 등 join이 필요한 추가 정보가 필요해, 
메인 행사 조회와 뒤풀이 신청 조회 API를 분리해서 구현하기로 결정했습니다.
- 두 API 모두 검색 조건 (신청자 이름, 학번, 전화번호) 는 동일해 재활용을 위해 `EventParticipantQueryOption` 을 생성했습니다.


## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 관리자용 애프터파티 참가자 조회 API 추가: 이벤트별 참가자 목록을 페이지 단위로 제공
  * 이름·학번·전화번호로 검색/필터링 지원
  * 참가자 기본정보(이름/학번/연락처)와 신청 상태, 애프터파티 신청·출석 상태, 사전/사후 결제 상태 포함 응답
  * 표준화된 페이지 응답으로 대용량 데이터 조회시 사용성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->