### PR TITLE
feat: 이벤트 신청정보 삭제 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
@@ -3,11 +3,14 @@ package com.gdschongik.gdsc.domain.event.api;
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus;
 import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
+import com.gdschongik.gdsc.domain.event.domain.Participant;
+import com.gdschongik.gdsc.domain.event.domain.ParticipantRole;
 import com.gdschongik.gdsc.domain.event.domain.PaymentStatus;
 import com.gdschongik.gdsc.domain.event.dto.EventParticipationDto;
 import com.gdschongik.gdsc.domain.event.dto.ParticipantDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipationDeleteRequest;
+import com.gdschongik.gdsc.domain.event.dto.response.EventApplicantResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -50,6 +53,23 @@ public class AdminEventParticipationController {
                 AfterPartyAttendanceStatus.NOT_ATTENDED,
                 PaymentStatus.UNPAID,
                 PaymentStatus.UNPAID));
+
+        var exampleResponse = new PageImpl<>(exampleContent, pageable, 1L);
+        return ResponseEntity.ok(exampleResponse);
+    }
+
+    @Operation(summary = "행사 신청자 목록 조회", description = "해당 행사의 신청자 목록을 조회합니다")
+    @GetMapping("/applicants")
+    public ResponseEntity<Page<EventApplicantResponse>> getEventApplicants(
+            @RequestParam(name = "event") Long eventId,
+            @ParameterObject EventParticipantQueryOption queryOption,
+            @ParameterObject Pageable pageable) {
+
+        // TODO: 임시 응답 제거 후 서비스 로직 구현
+        var exampleContent = List.of(new EventApplicantResponse(
+                Participant.of("김홍익", "C123456", "01012345678"),
+                AfterPartyApplicationStatus.APPLIED,
+                ParticipantRole.NON_MEMBER));
 
         var exampleResponse = new PageImpl<>(exampleContent, pageable, 1L);
         return ResponseEntity.ok(exampleResponse);

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/ParticipantDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/ParticipantDto.java
@@ -1,4 +1,6 @@
 package com.gdschongik.gdsc.domain.event.dto;
 
 @Deprecated
-public record ParticipantDto(String name, String studentId, String phone) {}
+public record ParticipantDto(String name, String studentId, String phone) {
+    // TODO: DTO 대신 VO를 사용하도록 변경 후 제거
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/ParticipantDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/ParticipantDto.java
@@ -1,3 +1,4 @@
 package com.gdschongik.gdsc.domain.event.dto;
 
+@Deprecated
 public record ParticipantDto(String name, String studentId, String phone) {}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/response/EventApplicantResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/response/EventApplicantResponse.java
@@ -1,0 +1,10 @@
+package com.gdschongik.gdsc.domain.event.dto.response;
+
+import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
+import com.gdschongik.gdsc.domain.event.domain.Participant;
+import com.gdschongik.gdsc.domain.event.domain.ParticipantRole;
+
+public record EventApplicantResponse(
+        Participant participant,
+        AfterPartyApplicationStatus afterPartyApplicationStatus,
+        ParticipantRole participantRole) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1117

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 관리자에서 행사 지원자 목록을 조회할 수 있습니다. 지원자의 기본 정보, 애프터파티 신청 상태, 역할을 확인할 수 있으며, 페이징으로 효율적으로 탐색할 수 있습니다.

- Chores
  - 참가자 관련 기존 데이터 구조에 사용 중단 예정 표시를 추가하고, 응답 모델을 정비하여 향후 마이그레이션을 준비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->