### PR TITLE
feat: 이벤트 신청인원 조회 로직 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
@@ -1,10 +1,9 @@
 package com.gdschongik.gdsc.domain.event.api;
 
+import com.gdschongik.gdsc.domain.event.application.EventParticipationService;
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus;
 import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
-import com.gdschongik.gdsc.domain.event.domain.Participant;
-import com.gdschongik.gdsc.domain.event.domain.ParticipantRole;
 import com.gdschongik.gdsc.domain.event.domain.PaymentStatus;
 import com.gdschongik.gdsc.domain.event.dto.EventParticipationDto;
 import com.gdschongik.gdsc.domain.event.dto.ParticipantDto;
@@ -28,6 +27,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/admin/event-participations")
 @RequiredArgsConstructor
 public class AdminEventParticipationController {
+
+    private final EventParticipationService eventParticipationService;
 
     @Operation(summary = "행사 신청 정보 삭제", description = "행사 신청 정보를 삭제합니다.")
     @DeleteMapping
@@ -64,14 +65,7 @@ public class AdminEventParticipationController {
             @RequestParam(name = "event") Long eventId,
             @ParameterObject EventParticipantQueryOption queryOption,
             @ParameterObject Pageable pageable) {
-
-        // TODO: 임시 응답 제거 후 서비스 로직 구현
-        var exampleContent = List.of(new EventApplicantResponse(
-                Participant.of("김홍익", "C123456", "01012345678"),
-                AfterPartyApplicationStatus.APPLIED,
-                ParticipantRole.NON_MEMBER));
-
-        var exampleResponse = new PageImpl<>(exampleContent, pageable, 1L);
-        return ResponseEntity.ok(exampleResponse);
+        var response = eventParticipationService.getEventApplicants(eventId, queryOption, pageable);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
@@ -1,0 +1,25 @@
+package com.gdschongik.gdsc.domain.event.application;
+
+import com.gdschongik.gdsc.domain.event.dao.EventParticipationRepository;
+import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
+import com.gdschongik.gdsc.domain.event.dto.response.EventApplicantResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventParticipationService {
+
+    private final EventParticipationRepository eventParticipationRepository;
+
+    @Transactional(readOnly = true)
+    public Page<EventApplicantResponse> getEventApplicants(
+            Long eventId, EventParticipantQueryOption queryOption, Pageable pageable) {
+        return eventParticipationRepository.findEventApplicants(eventId, queryOption, pageable);
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepository.java
@@ -1,0 +1,11 @@
+package com.gdschongik.gdsc.domain.event.dao;
+
+import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
+import com.gdschongik.gdsc.domain.event.dto.response.EventApplicantResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface EventParticipationCustomRepository {
+    Page<EventApplicantResponse> findEventApplicants(
+            Long eventId, EventParticipantQueryOption queryOption, Pageable pageable);
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
@@ -57,7 +57,7 @@ public class EventParticipationCustomRepositoryImpl
 
         Sort.Order order = sort.getOrderFor("createdAt");
 
-		// createdAt에 대한 정렬만 허용
+        // createdAt에 대한 정렬만 허용
         if (order == null) {
             throw new CustomException(SORT_NOT_SUPPORTED);
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
@@ -9,9 +9,7 @@ import com.gdschongik.gdsc.domain.event.dto.response.EventApplicantResponse;
 import com.gdschongik.gdsc.domain.event.dto.response.QEventApplicantResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Predicate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.annotation.Nullable;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +29,7 @@ public class EventParticipationCustomRepositoryImpl
             Long eventId, EventParticipantQueryOption queryOption, Pageable pageable) {
 
         OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifiers(pageable);
-        List<Long> ids = getIdsByQueryOption(eventId, queryOption, null, orderSpecifiers);
+        List<Long> ids = getIdsByQueryOption(eventId, queryOption, orderSpecifiers);
 
         List<EventApplicantResponse> fetch = jpaQueryFactory
                 .select(new QEventApplicantResponse(eventParticipation, member))
@@ -68,16 +66,13 @@ public class EventParticipationCustomRepositoryImpl
     }
 
     private List<Long> getIdsByQueryOption(
-            Long eventId,
-            EventParticipantQueryOption queryOption,
-            @Nullable Predicate predicate,
-            @NonNull OrderSpecifier<?>... orderSpecifiers) {
+            Long eventId, EventParticipantQueryOption queryOption, @NonNull OrderSpecifier<?>... orderSpecifiers) {
         return jpaQueryFactory
                 .select(eventParticipation.id)
                 .from(eventParticipation)
                 .leftJoin(member)
                 .on(eqMemberId())
-                .where(eqEventId(eventId), matchesEventParticipantQueryOption(queryOption), predicate)
+                .where(eqEventId(eventId), matchesEventParticipantQueryOption(queryOption), null)
                 .orderBy(orderSpecifiers)
                 .fetch();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
@@ -76,7 +76,7 @@ public class EventParticipationCustomRepositoryImpl
                 .select(eventParticipation.id)
                 .from(eventParticipation)
                 .leftJoin(member)
-                .on(eventParticipation.memberId.eq(member.id))
+                .on(eqMemberId())
                 .where(eqEventId(eventId), matchesEventParticipantQueryOption(queryOption), predicate)
                 .orderBy(orderSpecifiers)
                 .fetch();

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
@@ -1,0 +1,75 @@
+package com.gdschongik.gdsc.domain.event.dao;
+
+import static com.gdschongik.gdsc.domain.event.domain.QEventParticipation.*;
+import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
+
+import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
+import com.gdschongik.gdsc.domain.event.dto.response.EventApplicantResponse;
+import com.gdschongik.gdsc.domain.event.dto.response.QEventApplicantResponse;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class EventParticipationCustomRepositoryImpl
+        implements EventParticipationCustomRepository, EventParticipationQueryMethod {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<EventApplicantResponse> findEventApplicants(
+            Long eventId, EventParticipantQueryOption queryOption, Pageable pageable) {
+
+        OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifiers(pageable);
+        List<Long> ids = getIdsByQueryOption(eventId, queryOption, null, orderSpecifiers);
+
+        List<EventApplicantResponse> fetch = jpaQueryFactory
+                .select(new QEventApplicantResponse(eventParticipation, member))
+                .from(eventParticipation)
+                .leftJoin(member)
+                .on(eqMemberId())
+                .where(eventParticipation.id.in(ids))
+                .orderBy(orderSpecifiers)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return PageableExecutionUtils.getPage(fetch, pageable, ids::size);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        Sort sort = pageable.getSort();
+        Sort.Order order = sort.getOrderFor("createdAt");
+
+        if (sort.isUnsorted() || order == null) {
+            return new OrderSpecifier<?>[] {eventParticipation.createdAt.desc(), eventParticipation.id.desc()};
+        }
+
+        return order.isAscending()
+                ? new OrderSpecifier<?>[] {eventParticipation.createdAt.asc(), eventParticipation.id.asc()}
+                : new OrderSpecifier<?>[] {eventParticipation.createdAt.desc(), eventParticipation.id.desc()};
+    }
+
+    private List<Long> getIdsByQueryOption(
+            Long eventId,
+            EventParticipantQueryOption queryOption,
+            @Nullable Predicate predicate,
+            @NonNull OrderSpecifier<?>... orderSpecifiers) {
+        return jpaQueryFactory
+                .select(eventParticipation.id)
+                .from(eventParticipation)
+                .leftJoin(member)
+                .on(eventParticipation.memberId.eq(member.id))
+                .where(eqEventId(eventId), matchesEventParticipantQueryOption(queryOption), predicate)
+                .orderBy(orderSpecifiers)
+                .fetch();
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
@@ -2,10 +2,12 @@ package com.gdschongik.gdsc.domain.event.dao;
 
 import static com.gdschongik.gdsc.domain.event.domain.QEventParticipation.*;
 import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.gdschongik.gdsc.domain.event.dto.response.EventApplicantResponse;
 import com.gdschongik.gdsc.domain.event.dto.response.QEventApplicantResponse;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -47,10 +49,17 @@ public class EventParticipationCustomRepositoryImpl
 
     private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
         Sort sort = pageable.getSort();
+
+        // 정렬 기준이 없으면 기본값으로 최신순 정렬
+        if (sort.isUnsorted()) {
+            return new OrderSpecifier<?>[] {eventParticipation.createdAt.desc(), eventParticipation.id.desc()};
+        }
+
         Sort.Order order = sort.getOrderFor("createdAt");
 
-        if (sort.isUnsorted() || order == null) {
-            return new OrderSpecifier<?>[] {eventParticipation.createdAt.desc(), eventParticipation.id.desc()};
+		// createdAt에 대한 정렬만 허용
+        if (order == null) {
+            throw new CustomException(SORT_NOT_SUPPORTED);
         }
 
         return order.isAscending()

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationQueryMethod.java
@@ -1,0 +1,38 @@
+package com.gdschongik.gdsc.domain.event.dao;
+
+import static com.gdschongik.gdsc.domain.event.domain.QEventParticipation.*;
+import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
+
+import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public interface EventParticipationQueryMethod {
+
+    default BooleanBuilder matchesEventParticipantQueryOption(EventParticipantQueryOption queryOption) {
+        return new BooleanBuilder()
+                .and(eqName(queryOption.name()))
+                .and(eqStudentId(queryOption.studentId()))
+                .and(eqPhone(queryOption.phone()));
+    }
+
+    default BooleanExpression eqMemberId() {
+        return eventParticipation.memberId.eq(member.id);
+    }
+
+    default BooleanExpression eqEventId(Long eventId) {
+        return eventId != null ? eventParticipation.event.id.eq(eventId) : null;
+    }
+
+    default BooleanExpression eqName(String name) {
+        return name != null ? member.name.contains(name) : null;
+    }
+
+    default BooleanExpression eqStudentId(String studentId) {
+        return studentId != null ? member.studentId.containsIgnoreCase(studentId) : null;
+    }
+
+    default BooleanExpression eqPhone(String phone) {
+        return phone != null ? member.phone.containsIgnoreCase(phone) : null;
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationQueryMethod.java
@@ -33,6 +33,6 @@ public interface EventParticipationQueryMethod {
     }
 
     default BooleanExpression eqPhone(String phone) {
-        return phone != null ? member.phone.containsIgnoreCase(phone) : null;
+        return phone != null ? member.phone.contains(phone.replaceAll("-", "")) : null;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationRepository.java
@@ -1,0 +1,7 @@
+package com.gdschongik.gdsc.domain.event.dao;
+
+import com.gdschongik.gdsc.domain.event.domain.EventParticipation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventParticipationRepository
+        extends JpaRepository<EventParticipation, Long>, EventParticipationCustomRepository {}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventRepository.java
@@ -1,0 +1,6 @@
+package com.gdschongik.gdsc.domain.event.dao;
+
+import com.gdschongik.gdsc.domain.event.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/response/EventApplicantResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/response/EventApplicantResponse.java
@@ -1,10 +1,29 @@
 package com.gdschongik.gdsc.domain.event.dto.response;
 
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
+import com.gdschongik.gdsc.domain.event.domain.EventParticipation;
 import com.gdschongik.gdsc.domain.event.domain.Participant;
 import com.gdschongik.gdsc.domain.event.domain.ParticipantRole;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.querydsl.core.annotations.QueryProjection;
+import jakarta.annotation.Nullable;
 
 public record EventApplicantResponse(
+        Long eventParticipationId,
         Participant participant,
         AfterPartyApplicationStatus afterPartyApplicationStatus,
-        ParticipantRole participantRole) {}
+        ParticipantRole participantRole,
+        String discordUsername,
+        String nickname) {
+
+    @QueryProjection
+    public EventApplicantResponse(EventParticipation eventParticipation, @Nullable Member member) {
+        this(
+                eventParticipation.getId(),
+                eventParticipation.getParticipant(),
+                eventParticipation.getAfterPartyApplicationStatus(),
+                ParticipantRole.of(eventParticipation, member),
+                member == null ? null : member.getDiscordUsername(),
+                member == null ? null : member.getNickname());
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, "인자가 유효하지 않습니다."),
     REGEX_VIOLATION(BAD_REQUEST, "정규표현식을 위반했습니다."),
     FORBIDDEN_ACCESS(FORBIDDEN, "접근 권한이 없습니다."),
+    SORT_NOT_SUPPORTED(BAD_REQUEST, "지원되지 않는 정렬 기준입니다."),
 
     // Auth
     INVALID_JWT_TOKEN(UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
@@ -1,0 +1,178 @@
+package com.gdschongik.gdsc.domain.event.application;
+
+import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.event.dao.EventParticipationRepository;
+import com.gdschongik.gdsc.domain.event.dao.EventRepository;
+import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
+import com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus;
+import com.gdschongik.gdsc.domain.event.domain.Event;
+import com.gdschongik.gdsc.domain.event.domain.EventParticipation;
+import com.gdschongik.gdsc.domain.event.domain.PaymentStatus;
+import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
+import com.gdschongik.gdsc.domain.event.dto.response.EventApplicantResponse;
+import com.gdschongik.gdsc.domain.member.domain.Member;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.IntegrationTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class EventParticipationServiceTest extends IntegrationTest {
+
+    @Autowired
+    private EventParticipationService eventParticipationService;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventParticipationRepository eventParticipationRepository;
+
+    @Nested
+    class 이벤트_신청자_목록_조회할때 {
+
+        @Test
+        void 이벤트_ID가_일치하는_신청자만_조회된다() {
+            // given
+            Event event1 = createEvent();
+            Event event2 = createEvent();
+
+            Member member1 = createMember("C000001", "김홍익1");
+            Member member2 = createMember("C000002", "김홍익2");
+            Member member3 = createMember("B000001", "김홍익3");
+
+            // event1에 신청한 사용자들
+            createEventParticipation(event1, member1);
+            createEventParticipation(event1, member2);
+
+            // event2에 신청한 사용자
+            createEventParticipation(event2, member3);
+
+            EventParticipantQueryOption queryOption = new EventParticipantQueryOption(null, null, null);
+
+            // when
+            Page<EventApplicantResponse> result =
+                    eventParticipationService.getEventApplicants(event1.getId(), queryOption, PageRequest.of(0, 10));
+
+            // then
+            assertThat(result.getContent())
+                    .hasSize(2)
+                    .extracting(response -> response.participant().getStudentId())
+                    .containsExactlyInAnyOrder("C000001", "C000002");
+        }
+
+        @Test
+        void 학번_키워드를_포함하는_신청자만_조회된다() {
+            // given
+            Event event = createEvent();
+
+            Member memberC1 = createMember("C000001", "김홍익1");
+            Member memberC2 = createMember("C000002", "김홍익2");
+            Member memberB1 = createMember("B000001", "김홍익3");
+            Member memberB2 = createMember("B000002", "김홍익4");
+
+            createEventParticipation(event, memberC1);
+            createEventParticipation(event, memberC2);
+            createEventParticipation(event, memberB1);
+            createEventParticipation(event, memberB2);
+
+            EventParticipantQueryOption queryOption = new EventParticipantQueryOption(null, "C", null);
+
+            // when
+            Page<EventApplicantResponse> result =
+                    eventParticipationService.getEventApplicants(event.getId(), queryOption, PageRequest.of(0, 10));
+
+            // then
+            assertThat(result.getContent())
+                    .hasSize(2)
+                    .extracting(response -> response.participant().getStudentId())
+                    .containsExactlyInAnyOrder("C000001", "C000002");
+        }
+
+        @Test
+        void createdAt_오름차순으로_정렬된다() {
+            // given
+            Event event = createEvent();
+
+            Member member1 = createMember("C000001", "김홍익1");
+            Member member2 = createMember("C000002", "김홍익2");
+            Member member3 = createMember("C000003", "김홍익3");
+
+            // (3, 1, 2) 순서로 생성
+            EventParticipation participation3 = createEventParticipation(event, member3);
+            EventParticipation participation1 = createEventParticipation(event, member1);
+            EventParticipation participation2 = createEventParticipation(event, member2);
+
+            EventParticipantQueryOption queryOption = new EventParticipantQueryOption(null, null, null);
+            PageRequest pageRequest = PageRequest.of(0, 10, Sort.by("createdAt").ascending());
+
+            // when
+            Page<EventApplicantResponse> result =
+                    eventParticipationService.getEventApplicants(event.getId(), queryOption, pageRequest);
+
+            // then - (3, 1, 2) 순서로 조회되는지 확인
+            assertThat(result.getContent())
+                    .hasSize(3)
+                    .extracting(EventApplicantResponse::eventParticipationId)
+                    .containsExactly(participation3.getId(), participation1.getId(), participation2.getId());
+        }
+
+        @Test
+        void 지원하지_않는_정렬_조건이면_예외가_발생한다() {
+            // given
+            Event event = createEvent();
+
+            EventParticipantQueryOption queryOption = new EventParticipantQueryOption(null, null, null);
+            PageRequest pageRequest =
+                    PageRequest.of(0, 10, Sort.by("invalidField").ascending());
+
+            // when & then
+            assertThatThrownBy(
+                            () -> eventParticipationService.getEventApplicants(event.getId(), queryOption, pageRequest))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(SORT_NOT_SUPPORTED.getMessage());
+        }
+    }
+
+    private Event createEvent() {
+        Event event = Event.create(
+                EVENT_NAME,
+                VENUE,
+                EVENT_START_AT,
+                APPLICATION_DESCRIPTION,
+                EVENT_APPLICATION_PERIOD,
+                REGULAR_ROLE_ONLY_STATUS,
+                AFTER_PARTY_STATUS,
+                PRE_PAYMENT_STATUS,
+                POST_PAYMENT_STATUS,
+                RSVP_QUESTION_STATUS,
+                MAIN_EVENT_MAX_APPLICATION_COUNT,
+                AFTER_PARTY_MAX_APPLICATION_COUNT);
+        return eventRepository.save(event);
+    }
+
+    private Member createMember(String studentId, String name) {
+        Member member = createAssociateMember();
+        ReflectionTestUtils.setField(member, "studentId", studentId);
+        ReflectionTestUtils.setField(member, "name", name);
+        return memberRepository.save(member);
+    }
+
+    private EventParticipation createEventParticipation(Event event, Member member) {
+        EventParticipation eventParticipation = EventParticipation.createOnlineForRegistered(
+                member,
+                AfterPartyApplicationStatus.NOT_APPLIED,
+                AfterPartyAttendanceStatus.NOT_ATTENDED,
+                PaymentStatus.NONE,
+                PaymentStatus.NONE,
+                event);
+        return eventParticipationRepository.save(eventParticipation);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1132

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 이벤트 신청자 목록 API가 페이지네이션, 키워드 필터(이름/학번/전화) 및 생성일 기준 정렬을 지원합니다.
  - 응답에 참여 ID, 디스코드 사용자명, 닉네임 필드가 추가되어 관리자가 신청자 식별과 소통을 더 쉽게 할 수 있습니다.
  - 조회 로직이 서비스/저장소 계층으로 위임되어 실제 데이터 기반의 정렬·필터링 및 오류 처리가 적용됩니다.
  - 지원되지 않는 정렬 기준 요청 시 명확한 오류가 반환됩니다.

- 테스트
  - 이벤트별 필터링, 학번 키워드 검색, 생성일 정렬(오름차순), 미지원 정렬 오류 처리 및 비회원 처리에 대한 통합 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->