### PR TITLE
feat: 이벤트 뒤풀이 참석 처리 API 스펙 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
@@ -7,6 +7,7 @@ import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.PaymentStatus;
 import com.gdschongik.gdsc.domain.event.dto.EventParticipationDto;
 import com.gdschongik.gdsc.domain.event.dto.ParticipantDto;
+import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyAttendRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipationDeleteRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventApplicantResponse;
@@ -67,5 +68,12 @@ public class AdminEventParticipationController {
             @ParameterObject Pageable pageable) {
         var response = eventParticipationService.getEventApplicants(eventId, queryOption, pageable);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "뒤풀이 참석 처리", description = "뒤풀이에 참석 처리합니다.")
+    @PutMapping("/after-party/attend")
+    public ResponseEntity<Void> attendAfterParty(@Valid @RequestBody AfterPartyAttendRequest request) {
+        // TODO: 서비스 로직 구현
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/AfterPartyAttendRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/AfterPartyAttendRequest.java
@@ -1,0 +1,8 @@
+package com.gdschongik.gdsc.domain.event.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+public record AfterPartyAttendRequest(@NotEmpty List<@NotNull @Positive Long> eventParticipationIds) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1113

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 관리자 전용 뒤풀이 참석 처리 API 엔드포인트 추가(HTTP PUT /admin/event-participations/after-party/attend). 요청 본문으로 참석 대상의 참여 ID 목록을 받습니다.
  - 입력 유효성 검증 강화: 빈 목록, null, 음수 ID가 거부됩니다. 현재는 처리 로직 없이 200 OK(본문 없음)를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->