### PR TITLE
feat: 행사 생성 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
@@ -29,7 +29,7 @@ public final class Period {
         this.endDate = endDate;
     }
 
-    @JsonCreator
+    @JsonCreator // TODO: 레코드로 변경 후 제거
     public static Period of(LocalDateTime startDate, LocalDateTime endDate) {
         validatePeriod(startDate, endDate);
         return Period.builder().startDate(startDate).endDate(endDate).build();

--- a/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/common/vo/Period.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.domain.common.vo;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.Embeddable;
@@ -28,6 +29,7 @@ public final class Period {
         this.endDate = endDate;
     }
 
+    @JsonCreator
     public static Period of(LocalDateTime startDate, LocalDateTime endDate) {
         validatePeriod(startDate, endDate);
         return Period.builder().startDate(startDate).endDate(endDate).build();

--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
@@ -28,7 +28,7 @@ public class AdminEventController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "행사 생성", description = "행사를 생성합니다")
+    @Operation(summary = "행사 생성", description = "행사를 생성합니다.")
     @PostMapping
     public ResponseEntity<Void> createEvent(@Valid @RequestBody EventCreateRequest request) {
         eventService.createEvent(request);

--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
@@ -5,15 +5,13 @@ import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Event - Admin", description = "어드민 행사 관리 API입니다.")
 @RestController
@@ -32,7 +30,7 @@ public class AdminEventController {
 
     @Operation(summary = "행사 생성", description = "행사를 생성합니다")
     @PostMapping
-    public ResponseEntity<Void> createEvent(EventCreateRequest request) {
+    public ResponseEntity<Void> createEvent(@Valid @RequestBody EventCreateRequest request) {
         eventService.createEvent(request);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
@@ -1,6 +1,7 @@
 package com.gdschongik.gdsc.domain.event.api;
 
 import com.gdschongik.gdsc.domain.event.application.EventService;
+import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +28,12 @@ public class AdminEventController {
     public ResponseEntity<Page<EventResponse>> getEvents(@ParameterObject Pageable pageable) {
         var response = eventService.getEvents(pageable);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "행사 생성", description = "행사를 생성합니다")
+    @PostMapping
+    public ResponseEntity<Void> createEvent(EventCreateRequest request) {
+        eventService.createEvent(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.event.application;
 import com.gdschongik.gdsc.domain.event.dao.EventParticipationRepository;
 import com.gdschongik.gdsc.domain.event.dao.EventRepository;
 import com.gdschongik.gdsc.domain.event.domain.Event;
+import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +29,23 @@ public class EventService {
                 .toList();
 
         return new PageImpl<>(response, pageable, events.getTotalElements());
+    }
+
+    @Transactional
+    public void createEvent(EventCreateRequest request) {
+        Event event = Event.create(
+                request.name(),
+                request.venue(),
+                request.startAt(),
+                request.applicationDescription(),
+                request.applicationPeriod(),
+                request.regularRoleOnlyStatus(),
+                request.afterPartyStatus(),
+                request.prePaymentStatus(),
+                request.postPaymentStatus(),
+                request.rsvpQuestionStatus(),
+                request.mainEventMaxApplicantCount(),
+                request.afterPartyMaxApplicantCount());
+        eventRepository.save(event);
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -49,6 +49,7 @@ public class EventService {
                 request.mainEventMaxApplicantCount(),
                 request.afterPartyMaxApplicantCount());
         eventRepository.save(event);
+
         log.info("[EventService] 이벤트 생성: eventId={}", event.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -7,12 +7,14 @@ import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventService {
@@ -47,5 +49,6 @@ public class EventService {
                 request.mainEventMaxApplicantCount(),
                 request.afterPartyMaxApplicantCount());
         eventRepository.save(event);
+        log.info("[EventService] 이벤트 생성: eventId={}", event.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
@@ -2,15 +2,16 @@ package com.gdschongik.gdsc.domain.event.dto.request;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.event.domain.UsageStatus;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 
 public record EventCreateRequest(
-        @NotNull String name,
+        @NotBlank String name,
         String venue,
         @NotNull LocalDateTime startAt,
-        String applicationDescription,
+        @NotBlank String applicationDescription,
         @NotNull Period applicationPeriod,
         @NotNull UsageStatus regularRoleOnlyStatus,
         @NotNull UsageStatus afterPartyStatus,

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
@@ -1,0 +1,21 @@
+package com.gdschongik.gdsc.domain.event.dto.request;
+
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.event.domain.UsageStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDateTime;
+
+public record EventCreateRequest(
+        @NotNull String name,
+        String venue,
+        @NotNull LocalDateTime startAt,
+        String applicationDescription,
+        @NotNull Period applicationPeriod,
+        @NotNull UsageStatus regularRoleOnlyStatus,
+        @NotNull UsageStatus afterPartyStatus,
+        @NotNull UsageStatus prePaymentStatus,
+        @NotNull UsageStatus postPaymentStatus,
+        @NotNull UsageStatus rsvpQuestionStatus,
+        @Positive Integer mainEventMaxApplicantCount,
+        @Positive Integer afterPartyMaxApplicantCount) {}

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
@@ -1,0 +1,42 @@
+package com.gdschongik.gdsc.domain.event.application;
+
+import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
+import com.gdschongik.gdsc.helper.IntegrationTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class EventServiceTest extends IntegrationTest {
+
+    @Autowired
+    private EventService eventService;
+
+    @Nested
+    class 이벤트_생성시 {
+
+        @Test
+        void 성공한다() {
+            // given
+            var request = new EventCreateRequest(
+                    EVENT_NAME,
+                    VENUE,
+                    EVENT_START_AT,
+                    APPLICATION_DESCRIPTION,
+                    EVENT_APPLICATION_PERIOD,
+                    REGULAR_ROLE_ONLY_STATUS,
+                    AFTER_PARTY_STATUS,
+                    PRE_PAYMENT_STATUS,
+                    POST_PAYMENT_STATUS,
+                    RSVP_QUESTION_STATUS,
+                    MAIN_EVENT_MAX_APPLICATION_COUNT,
+                    AFTER_PARTY_MAX_APPLICATION_COUNT);
+
+            // when & then
+            assertThatCode(() -> eventService.createEvent(request)).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/EventConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/EventConstant.java
@@ -13,8 +13,10 @@ public class EventConstant {
             "2025년 1학기 새내기 배움터 신청 폼입니다. 진행일시는 3월 15일, 신청 기간은 3월 1일부터 3월 14일까지입니다.";
     public static final String VENUE = "홍익대학교 제 4공학관(T동) 608호";
     public static final LocalDateTime EVENT_START_AT = LocalDateTime.of(2025, 3, 15, 0, 0);
+    public static final LocalDateTime EVENT_APPLICATION_START_AT = LocalDateTime.of(2025, 3, 1, 0, 0);
+    public static final LocalDateTime EVENT_APPLICATION_END_AT = LocalDateTime.of(2025, 3, 14, 23, 59);
     public static final Period EVENT_APPLICATION_PERIOD =
-            Period.of(LocalDateTime.of(2025, 3, 1, 0, 0), LocalDateTime.of(2025, 3, 14, 23, 59));
+            Period.of(EVENT_APPLICATION_START_AT, EVENT_APPLICATION_END_AT);
     public static final UsageStatus REGULAR_ROLE_ONLY_STATUS = UsageStatus.DISABLED;
     public static final UsageStatus AFTER_PARTY_STATUS = UsageStatus.ENABLED;
     public static final UsageStatus PRE_PAYMENT_STATUS = UsageStatus.ENABLED;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1163

## 📌 작업 내용 및 특이사항
- StudyV2 생성 API 를 참고해서 로직과 dto를 구현했습니다.

- StudyV2 생성 로직을 보다 발견한건데 Period 검증 관련해서 (필드 null 유무 && startDate < endDate 여부)
  - 지금 StudyV2 생성 로직에선 applicationPeriod 검증이 빠져있던데 의도된건가요? 
  - 그게 아니라면 어플리케이션에서 입력된 Period의 유효성을 다시 검사해야 하는데, VO가 생성된 이후에 유효한지를 검사하는것도 좀 이상하지 않나 싶습니다..
  - 아래처럼 일괄적으로 변경하는건 어떤가요? (대신 StudyV2 create의 API 명세가 변경되는걸 감안해야합니다)

## 📝 참고사항
```java
public record EventCreateRequest {
    ...
    LocalDateTime startDate, // 입력 dto에서는 분리해서 받고
    LocalDateTime endDate,
    ...
}

public class EventService {
    
    public void createEvent(EventCreateRequest request) {
        ...
        Period applicationPeriod = Period.of(request.startDate(), request.endDate()); // 서비스에서 Period 생성하면서 검사
        Event.create(applicationPeriod);
    }
}
```

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 관리자용 이벤트 생성 API가 추가되었습니다 (POST /admin/events). 이름·시작일시·신청기간 등 유효성 검사를 적용한 생성 페이로드를 받아 처리하며, 성공 시 200 OK를 반환합니다.
- 테스트
  - 이벤트 생성 통합 테스트가 추가되었습니다.
  - 테스트 신뢰성을 위해 신청 기간의 시작/종료 시각 상수가 보강되었습니다.
- 개선
  - 기간 정보 직렬화/역직렬화 처리 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->