### PR TITLE
feat: 이벤트 수정 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
@@ -47,7 +47,7 @@ public class AdminEventController {
 
     @Operation(summary = "이벤트 수정", description = "이벤트 기본 정보를 수정합니다.")
     @PutMapping("/{eventId}")
-    public ResponseEntity<Void> createEvent(
+    public ResponseEntity<Void> updateEvent(
             @PathVariable Long eventId, @Valid @RequestBody EventUpdateRequest request) {
         eventService.updateEvent(eventId, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
@@ -3,6 +3,7 @@ package com.gdschongik.gdsc.domain.event.api;
 import com.gdschongik.gdsc.domain.event.application.EventService;
 import com.gdschongik.gdsc.domain.event.dto.dto.EventDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,5 +43,13 @@ public class AdminEventController {
     public ResponseEntity<List<EventDto>> searchEvent(@RequestParam String name) {
         var response = eventService.searchEvent(name);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "이벤트 수정", description = "이벤트 기본 정보를 수정합니다.")
+    @PutMapping("/{eventId}")
+    public ResponseEntity<Void> createEvent(
+            @PathVariable Long eventId, @Valid @RequestBody EventUpdateRequest request) {
+        eventService.updateEvent(eventId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -1,11 +1,15 @@
 package com.gdschongik.gdsc.domain.event.application;
 
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
 import com.gdschongik.gdsc.domain.event.dao.EventParticipationRepository;
 import com.gdschongik.gdsc.domain.event.dao.EventRepository;
 import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.domain.event.dto.dto.EventDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,5 +62,23 @@ public class EventService {
     public List<EventDto> searchEvent(String name) {
         List<Event> events = eventRepository.findAllByNameContains(name);
         return events.stream().map(EventDto::from).toList();
+    }
+
+    @Transactional
+    public void updateEvent(Long eventId, EventUpdateRequest request) {
+        Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
+
+        event.update(
+                request.name(),
+                request.venue(),
+                request.startAt(),
+                request.applicationDescription(),
+                request.applicationPeriod(),
+                request.mainEventMaxApplicantCount(),
+                request.afterPartyMaxApplicantCount());
+
+        eventRepository.save(event);
+
+        log.info("[EventService] 이벤트 수정 완료: eventId={}", event.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
@@ -158,9 +158,28 @@ public class Event extends BaseEntity {
         }
     }
 
-    // 데이터 조회 로직
+    // 데이터 조회 메서드
 
     public boolean afterPartyExists() {
         return afterPartyStatus.isEnabled();
+    }
+
+    // 수정 메서드
+
+    public void update(
+            String name,
+            String venue,
+            LocalDateTime startAt,
+            String applicationDescription,
+            Period applicationPeriod,
+            Integer mainEventMaxApplicantCount,
+            Integer afterPartyMaxApplicantCount) {
+        this.name = name;
+        this.venue = venue;
+        this.startAt = startAt;
+        this.applicationDescription = applicationDescription;
+        this.applicationPeriod = applicationPeriod;
+        this.mainEventMaxApplicantCount = mainEventMaxApplicantCount;
+        this.afterPartyMaxApplicantCount = afterPartyMaxApplicantCount;
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventUpdateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.gdschongik.gdsc.domain.event.dto.request;
+
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDateTime;
+
+public record EventUpdateRequest(
+        @NotBlank String name,
+        String venue,
+        @NotNull LocalDateTime startAt,
+        @NotBlank String applicationDescription,
+        @NotNull Period applicationPeriod,
+        @Positive Integer mainEventMaxApplicantCount,
+        @Positive Integer afterPartyMaxApplicantCount) {}

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
@@ -473,23 +473,6 @@ class EventParticipationServiceTest extends IntegrationTest {
         }
     }
 
-    private Event createEvent() {
-        Event event = Event.create(
-                EVENT_NAME,
-                VENUE,
-                EVENT_START_AT,
-                APPLICATION_DESCRIPTION,
-                EVENT_APPLICATION_PERIOD,
-                REGULAR_ROLE_ONLY_STATUS,
-                AFTER_PARTY_STATUS,
-                PRE_PAYMENT_STATUS,
-                POST_PAYMENT_STATUS,
-                RSVP_QUESTION_STATUS,
-                MAIN_EVENT_MAX_APPLICATION_COUNT,
-                AFTER_PARTY_MAX_APPLICATION_COUNT);
-        return eventRepository.save(event);
-    }
-
     private Event createAfterPartyDisabledEvent() {
         Event event = Event.create(
                 EVENT_NAME,

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateRequest;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,32 @@ public class EventServiceTest extends IntegrationTest {
 
             // when & then
             assertThatCode(() -> eventService.createEvent(request)).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class 이벤트_수정시 {
+
+        @Test
+        void 성공한다() {
+            // given
+            createEvent();
+
+            String updatedName = "수정된 행사 이름";
+            var request = new EventUpdateRequest(
+                    updatedName,
+                    VENUE,
+                    EVENT_START_AT,
+                    APPLICATION_DESCRIPTION,
+                    EVENT_APPLICATION_PERIOD,
+                    MAIN_EVENT_MAX_APPLICATION_COUNT,
+                    AFTER_PARTY_MAX_APPLICATION_COUNT);
+
+            // when
+            eventService.updateEvent(1L, request);
+
+            // then
+            assertThat(eventRepository.findById(1L).get().getName()).isEqualTo(updatedName);
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
@@ -4,8 +4,10 @@ import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateRequest;
+import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,9 +47,29 @@ public class EventServiceTest extends IntegrationTest {
     class 이벤트_수정시 {
 
         @Test
+        void 존재하지_않는_이벤트일_경우_실패한다() {
+            // given
+            String updatedName = "수정된 행사 이름";
+            var request = new EventUpdateRequest(
+                    updatedName,
+                    VENUE,
+                    EVENT_START_AT,
+                    APPLICATION_DESCRIPTION,
+                    EVENT_APPLICATION_PERIOD,
+                    MAIN_EVENT_MAX_APPLICATION_COUNT,
+                    AFTER_PARTY_MAX_APPLICATION_COUNT);
+
+            // when & then
+            assertThatThrownBy(() -> eventService.updateEvent(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(EVENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
         void 성공한다() {
             // given
-            createEvent();
+            Event event = createEvent();
+            Long eventId = event.getId();
 
             String updatedName = "수정된 행사 이름";
             var request = new EventUpdateRequest(
@@ -60,10 +82,10 @@ public class EventServiceTest extends IntegrationTest {
                     AFTER_PARTY_MAX_APPLICATION_COUNT);
 
             // when
-            eventService.updateEvent(1L, request);
+            eventService.updateEvent(eventId, request);
 
             // then
-            assertThat(eventRepository.findById(1L).get().getName()).isEqualTo(updatedName);
+            assertThat(eventRepository.findById(eventId).get().getName()).isEqualTo(updatedName);
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -2,6 +2,7 @@ package com.gdschongik.gdsc.helper;
 
 import static com.gdschongik.gdsc.domain.member.domain.Department.*;
 import static com.gdschongik.gdsc.global.common.constant.CouponConstant.*;
+import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.RecruitmentConstant.*;
 import static com.gdschongik.gdsc.global.common.constant.StudyConstant.*;
@@ -20,6 +21,8 @@ import com.gdschongik.gdsc.domain.coupon.domain.IssuedCoupon;
 import com.gdschongik.gdsc.domain.discord.application.handler.DelegateMemberDiscordEventHandler;
 import com.gdschongik.gdsc.domain.discord.application.handler.MemberDiscordRoleRevokeHandler;
 import com.gdschongik.gdsc.domain.discord.application.handler.SpringEventHandler;
+import com.gdschongik.gdsc.domain.event.dao.EventRepository;
+import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.domain.member.dao.MemberRepository;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.domain.member.domain.MemberManageRole;
@@ -109,6 +112,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected StudyHistoryV2Repository studyHistoryV2Repository;
+
+    @Autowired
+    protected EventRepository eventRepository;
 
     @MockBean
     protected OnboardingRecruitmentService onboardingRecruitmentService;
@@ -330,5 +336,23 @@ public abstract class IntegrationTest {
     protected StudyHistoryV2 createStudyHistory(Member member, StudyV2 study) {
         StudyHistoryV2 studyHistory = StudyHistoryV2.create(member, study);
         return studyHistoryV2Repository.save(studyHistory);
+    }
+
+    protected Event createEvent() {
+        Event event = Event.create(
+                EVENT_NAME,
+                VENUE,
+                EVENT_START_AT,
+                APPLICATION_DESCRIPTION,
+                EVENT_APPLICATION_PERIOD,
+                REGULAR_ROLE_ONLY_STATUS,
+                AFTER_PARTY_STATUS,
+                PRE_PAYMENT_STATUS,
+                POST_PAYMENT_STATUS,
+                RSVP_QUESTION_STATUS,
+                MAIN_EVENT_MAX_APPLICATION_COUNT,
+                AFTER_PARTY_MAX_APPLICATION_COUNT);
+
+        return eventRepository.save(event);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1182

## 📌 작업 내용 및 특이사항
<img width="350" height="530" alt="스크린샷 2025-09-03 오후 10 58 35" src="https://github.com/user-attachments/assets/6e43cfd4-b87a-4c71-adca-7ecc90ebb48a" />

이벤트 수정 시 폼 관련 정보를 수정 가능하게 해버리면, 이벤트 참여 신청이 이미 진행된 후에 폼 정보 변경 -> 기존 신청에서 정합성 문제 발생
기본 정보 + 인원 제한 정보만 수정 가능하도록 구현

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 새로운 기능
  * 관리자용 이벤트 정보 수정 기능 추가(성공 시 200 응답). 요청 값 유효성 검증 및 API 문서화(스웨거) 적용.
* 버그 수정/안정성
  * 존재하지 않는 이벤트 수정 시 적절한 오류 처리 추가.
* 테스트
  * 이벤트 수정 동작을 검증하는 단위 테스트 추가.
  * 통합 테스트용 이벤트 생성 유틸리티 도입으로 테스트 재사용성·안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->