### PR TITLE
feat: 이벤트 신청 인원 제한 변경 제약사항 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
@@ -6,7 +6,7 @@ import com.gdschongik.gdsc.domain.event.dao.EventParticipationRepository;
 import com.gdschongik.gdsc.domain.event.dao.EventRepository;
 import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.domain.event.domain.EventParticipation;
-import com.gdschongik.gdsc.domain.event.domain.EventParticipationDomainService;
+import com.gdschongik.gdsc.domain.event.domain.service.EventParticipationDomainService;
 import com.gdschongik.gdsc.domain.event.dto.dto.EventParticipableMemberDto;
 import com.gdschongik.gdsc.domain.event.dto.dto.EventParticipationDto;
 import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyAttendRequest;

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -70,11 +70,11 @@ public class EventService {
     public void updateEvent(Long eventId, EventUpdateRequest request) {
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
 
-        int currentMainEventApplicants = eventParticipationRepository.countMainEventApplicantsByEvent(event);
+        long currentMainEventApplicants = eventParticipationRepository.countMainEventApplicantsByEvent(event);
         eventDomainService.validateWhenUpdateMaxApplicantCount(
                 currentMainEventApplicants, request.mainEventMaxApplicantCount());
 
-        int currentAfterPartyApplicants = eventParticipationRepository.countAfterPartyApplicantsByEvent(event);
+        long currentAfterPartyApplicants = eventParticipationRepository.countAfterPartyApplicantsByEvent(event);
         eventDomainService.validateWhenUpdateMaxApplicantCount(
                 currentAfterPartyApplicants, request.afterPartyMaxApplicantCount());
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -69,24 +69,20 @@ public class EventService {
     @Transactional
     public void updateEvent(Long eventId, EventUpdateRequest request) {
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
-
         long currentMainEventApplicantCount = eventParticipationRepository.countMainEventApplicantsByEvent(event);
         long currentAfterPartyApplicantCount = eventParticipationRepository.countAfterPartyApplicantsByEvent(event);
 
-        eventDomainService.validateUpdate(
-                currentMainEventApplicantCount,
-                request.mainEventMaxApplicantCount(),
-                currentAfterPartyApplicantCount,
-                request.afterPartyMaxApplicantCount());
-
-        event.update(
+        eventDomainService.update(
+                event,
                 request.name(),
                 request.venue(),
                 request.startAt(),
                 request.applicationDescription(),
                 request.applicationPeriod(),
                 request.mainEventMaxApplicantCount(),
-                request.afterPartyMaxApplicantCount());
+                request.afterPartyMaxApplicantCount(),
+                currentMainEventApplicantCount,
+                currentAfterPartyApplicantCount);
 
         eventRepository.save(event);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -70,13 +70,14 @@ public class EventService {
     public void updateEvent(Long eventId, EventUpdateRequest request) {
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
 
-        long currentMainEventApplicants = eventParticipationRepository.countMainEventApplicantsByEvent(event);
-        eventDomainService.validateUpdateMaxApplicantCount(
-                currentMainEventApplicants, request.mainEventMaxApplicantCount());
+        long currentMainEventApplicantCount = eventParticipationRepository.countMainEventApplicantsByEvent(event);
+        long currentAfterPartyApplicantCount = eventParticipationRepository.countAfterPartyApplicantsByEvent(event);
 
-        long currentAfterPartyApplicants = eventParticipationRepository.countAfterPartyApplicantsByEvent(event);
-        eventDomainService.validateUpdateMaxApplicantCount(
-                currentAfterPartyApplicants, request.afterPartyMaxApplicantCount());
+        eventDomainService.validateUpdate(
+                currentMainEventApplicantCount,
+                request.mainEventMaxApplicantCount(),
+                currentAfterPartyApplicantCount,
+                request.afterPartyMaxApplicantCount());
 
         event.update(
                 request.name(),

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -71,11 +71,11 @@ public class EventService {
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
 
         long currentMainEventApplicants = eventParticipationRepository.countMainEventApplicantsByEvent(event);
-        eventDomainService.validateWhenUpdateMaxApplicantCount(
+        eventDomainService.validateUpdateMaxApplicantCount(
                 currentMainEventApplicants, request.mainEventMaxApplicantCount());
 
         long currentAfterPartyApplicants = eventParticipationRepository.countAfterPartyApplicantsByEvent(event);
-        eventDomainService.validateWhenUpdateMaxApplicantCount(
+        eventDomainService.validateUpdateMaxApplicantCount(
                 currentAfterPartyApplicants, request.afterPartyMaxApplicantCount());
 
         event.update(

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepository.java
@@ -14,7 +14,7 @@ public interface EventParticipationCustomRepository {
     AfterPartyApplicantResponse findAfterPartyApplicants(
             Long eventId, EventParticipantQueryOption queryOption, Pageable pageable);
 
-    int countMainEventApplicantsByEvent(Event event);
+    long countMainEventApplicantsByEvent(Event event);
 
-    int countAfterPartyApplicantsByEvent(Event event);
+    long countAfterPartyApplicantsByEvent(Event event);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepository.java
@@ -1,5 +1,6 @@
 package com.gdschongik.gdsc.domain.event.dao;
 
+import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.gdschongik.gdsc.domain.event.dto.response.AfterPartyApplicantResponse;
 import com.gdschongik.gdsc.domain.event.dto.response.EventApplicantResponse;
@@ -12,4 +13,8 @@ public interface EventParticipationCustomRepository {
 
     AfterPartyApplicantResponse findAfterPartyApplicants(
             Long eventId, EventParticipantQueryOption queryOption, Pageable pageable);
+
+    int countMainEventApplicantsByEvent(Event event);
+
+    int countAfterPartyApplicantsByEvent(Event event);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
@@ -26,6 +26,7 @@ import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -192,20 +193,20 @@ public class EventParticipationCustomRepositoryImpl
     }
 
     @Override
-    public int countMainEventApplicantsByEvent(Event event) {
-        return jpaQueryFactory
-                .selectFrom(eventParticipation)
+    public long countMainEventApplicantsByEvent(Event event) {
+        return Objects.requireNonNull(jpaQueryFactory
+                .select(eventParticipation.count())
+                .from(eventParticipation)
                 .where(eqEventId(event.getId()), eqMainEventApplicationStatus(MainEventApplicationStatus.APPLIED))
-                .fetch()
-                .size();
+                .fetchOne());
     }
 
     @Override
-    public int countAfterPartyApplicantsByEvent(Event event) {
-        return jpaQueryFactory
-                .selectFrom(eventParticipation)
+    public long countAfterPartyApplicantsByEvent(Event event) {
+        return Objects.requireNonNull(jpaQueryFactory
+                .select(eventParticipation.count())
+                .from(eventParticipation)
                 .where(eqEventId(event.getId()), eqAfterPartyApplicationStatus(APPLIED))
-                .fetch()
-                .size();
+                .fetchOne());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
@@ -1,12 +1,12 @@
 package com.gdschongik.gdsc.domain.event.dao;
 
-import static com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus.*;
 import static com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus.ATTENDED;
 import static com.gdschongik.gdsc.domain.event.domain.PaymentStatus.*;
 import static com.gdschongik.gdsc.domain.event.domain.QEventParticipation.*;
 import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
 import com.gdschongik.gdsc.domain.event.dto.dto.AfterPartyApplicantCountDto;
@@ -105,7 +105,8 @@ public class EventParticipationCustomRepositoryImpl
                 .from(eventParticipation)
                 .where(
                         eqEventId(eventId),
-                        eqAfterPartyApplicationStatus(APPLIED).or(eqAfterPartyAttendanceStatus(ATTENDED)),
+                        eqAfterPartyApplicationStatus(AfterPartyApplicationStatus.APPLIED)
+                                .or(eqAfterPartyAttendanceStatus(ATTENDED)),
                         matchesEventParticipantQueryOption(queryOption))
                 .orderBy(orderSpecifiers)
                 .fetch();
@@ -114,7 +115,8 @@ public class EventParticipationCustomRepositoryImpl
     private QAfterPartyApplicantCountDto getEventParticipationCounts() {
         return new QAfterPartyApplicantCountDto(
                 Expressions.cases()
-                        .when(eqAfterPartyApplicationStatus(APPLIED).or(eqAfterPartyAttendanceStatus(ATTENDED)))
+                        .when(eqAfterPartyApplicationStatus(AfterPartyApplicationStatus.APPLIED)
+                                .or(eqAfterPartyAttendanceStatus(ATTENDED)))
                         .then(eventParticipation.id)
                         .otherwise((Long) null)
                         .count(),
@@ -206,7 +208,7 @@ public class EventParticipationCustomRepositoryImpl
         return Objects.requireNonNull(jpaQueryFactory
                 .select(eventParticipation.count())
                 .from(eventParticipation)
-                .where(eqEventId(event.getId()), eqAfterPartyApplicationStatus(APPLIED))
+                .where(eqEventId(event.getId()), eqAfterPartyApplicationStatus(AfterPartyApplicationStatus.APPLIED))
                 .fetchOne());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
@@ -93,6 +93,7 @@ public class EventParticipationCustomRepositoryImpl
         AfterPartyApplicantCountDto counts = jpaQueryFactory
                 .select(getEventParticipationCounts())
                 .from(eventParticipation)
+                .where(eqEventId(eventId))
                 .fetchOne();
 
         return AfterPartyApplicantResponse.of(PageableExecutionUtils.getPage(fetch, pageable, ids::size), counts);

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationCustomRepositoryImpl.java
@@ -1,12 +1,14 @@
 package com.gdschongik.gdsc.domain.event.dao;
 
-import static com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus.APPLIED;
+import static com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus.*;
 import static com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus.ATTENDED;
 import static com.gdschongik.gdsc.domain.event.domain.PaymentStatus.*;
 import static com.gdschongik.gdsc.domain.event.domain.QEventParticipation.*;
 import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.event.domain.Event;
+import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
 import com.gdschongik.gdsc.domain.event.dto.dto.AfterPartyApplicantCountDto;
 import com.gdschongik.gdsc.domain.event.dto.dto.EventParticipationDto;
 import com.gdschongik.gdsc.domain.event.dto.dto.QAfterPartyApplicantCountDto;
@@ -187,5 +189,23 @@ public class EventParticipationCustomRepositoryImpl
             }
         }
         return orders.toArray(OrderSpecifier[]::new);
+    }
+
+    @Override
+    public int countMainEventApplicantsByEvent(Event event) {
+        return jpaQueryFactory
+                .selectFrom(eventParticipation)
+                .where(eqEventId(event.getId()), eqMainEventApplicationStatus(MainEventApplicationStatus.APPLIED))
+                .fetch()
+                .size();
+    }
+
+    @Override
+    public int countAfterPartyApplicantsByEvent(Event event) {
+        return jpaQueryFactory
+                .selectFrom(eventParticipation)
+                .where(eqEventId(event.getId()), eqAfterPartyApplicationStatus(APPLIED))
+                .fetch()
+                .size();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationQueryMethod.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationQueryMethod.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.domain.member.domain.QMember.*;
 
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.AfterPartyAttendanceStatus;
+import com.gdschongik.gdsc.domain.event.domain.MainEventApplicationStatus;
 import com.gdschongik.gdsc.domain.event.domain.PaymentStatus;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.querydsl.core.BooleanBuilder;
@@ -37,6 +38,10 @@ public interface EventParticipationQueryMethod {
 
     default BooleanExpression eqPhone(String phone) {
         return phone != null ? eventParticipation.participant.phone.contains(phone.replaceAll("-", "")) : null;
+    }
+
+    default BooleanExpression eqMainEventApplicationStatus(MainEventApplicationStatus status) {
+        return status != null ? eventParticipation.mainEventApplicationStatus.eq(status) : null;
     }
 
     default BooleanExpression eqAfterPartyApplicationStatus(AfterPartyApplicationStatus status) {

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.event.domain.service.EventDomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -166,6 +167,11 @@ public class Event extends BaseEntity {
 
     // 수정 메서드
 
+    /**
+     * 이벤트 정보를 수정합니다.
+     * 도메인 서비스를 통해서만 호출되어야 합니다.
+     * @see EventDomainService
+     */
     public void update(
             String name,
             String venue,

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
@@ -10,9 +10,25 @@ import jakarta.annotation.Nullable;
 public class EventDomainService {
 
     /**
-     * 행사의 최대 신청자 수를 변경할 때, 현재 신청자 수보다 낮게 설정하는 경우 예외를 발생시킵니다.
+     * 이벤트를 변경할 때 제약 사항을 검증합니다.
+     * @param currentMainEventApplicantCount 현재 본 행사 신청자 수. EventParticipationRepository 조회 데이터
+     * @param newMaxMainEventApplicantCount 변경하려는 본 행사 최대 신청자 수. (인원 제한이 없는 경우 null)
+     * @param currentAfterPartyApplicantCount 현재 뒤풀이 신청자 수. EventParticipationRepository 조회 데이터
+     * @param newMaxAfterPartyApplicantCount 변경하려는 뒤풀이 최대 신청자 수. (인원 제한이 없는 경우 null)
      */
-    public void validateUpdateMaxApplicantCount(long currentApplicantCount, @Nullable Integer newMaxApplicantCount) {
+    public void validateUpdate(
+            long currentMainEventApplicantCount,
+            @Nullable Integer newMaxMainEventApplicantCount,
+            long currentAfterPartyApplicantCount,
+            @Nullable Integer newMaxAfterPartyApplicantCount) {
+        validateUpdateMaxApplicantCount(currentMainEventApplicantCount, newMaxMainEventApplicantCount);
+        validateUpdateMaxApplicantCount(currentAfterPartyApplicantCount, newMaxAfterPartyApplicantCount);
+    }
+
+    /**
+     * 이벤트의 최대 신청자 수를 변경할 때, 현재 신청자 수보다 낮게 설정하는 경우 예외를 발생시킵니다.
+     */
+    private void validateUpdateMaxApplicantCount(long currentApplicantCount, @Nullable Integer newMaxApplicantCount) {
         if (newMaxApplicantCount == null) { // 인원 제한을 없애는 경우 항상 허용
             return;
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
@@ -2,27 +2,45 @@ package com.gdschongik.gdsc.domain.event.domain.service;
 
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
+import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.annotation.Nullable;
+import java.time.LocalDateTime;
 
 @DomainService
 public class EventDomainService {
 
     /**
-     * 이벤트를 변경할 때 제약 사항을 검증합니다.
+     * 이벤트를 변경합니다.
+     * @param mainEventMaxApplicantCount 변경하려는 본 행사 최대 신청자 수. (인원 제한이 없는 경우 null)
+     * @param afterPartyMaxApplicantCount 변경하려는 뒤풀이 최대 신청자 수. (인원 제한이 없는 경우 null)
      * @param currentMainEventApplicantCount 현재 본 행사 신청자 수. EventParticipationRepository 조회 데이터
-     * @param newMaxMainEventApplicantCount 변경하려는 본 행사 최대 신청자 수. (인원 제한이 없는 경우 null)
      * @param currentAfterPartyApplicantCount 현재 뒤풀이 신청자 수. EventParticipationRepository 조회 데이터
-     * @param newMaxAfterPartyApplicantCount 변경하려는 뒤풀이 최대 신청자 수. (인원 제한이 없는 경우 null)
      */
-    public void validateUpdate(
+    public void update(
+            Event event,
+            String name,
+            String venue,
+            LocalDateTime startAt,
+            String applicationDescription,
+            Period applicationPeriod,
+            @Nullable Integer mainEventMaxApplicantCount,
+            @Nullable Integer afterPartyMaxApplicantCount,
             long currentMainEventApplicantCount,
-            @Nullable Integer newMaxMainEventApplicantCount,
-            long currentAfterPartyApplicantCount,
-            @Nullable Integer newMaxAfterPartyApplicantCount) {
-        validateUpdateMaxApplicantCount(currentMainEventApplicantCount, newMaxMainEventApplicantCount);
-        validateUpdateMaxApplicantCount(currentAfterPartyApplicantCount, newMaxAfterPartyApplicantCount);
+            long currentAfterPartyApplicantCount) {
+        validateUpdateMaxApplicantCount(currentMainEventApplicantCount, mainEventMaxApplicantCount);
+        validateUpdateMaxApplicantCount(currentAfterPartyApplicantCount, afterPartyMaxApplicantCount);
+
+        event.update(
+                name,
+                venue,
+                startAt,
+                applicationDescription,
+                applicationPeriod,
+                mainEventMaxApplicantCount,
+                afterPartyMaxApplicantCount);
     }
 
     /**

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
@@ -12,7 +12,7 @@ public class EventDomainService {
     /**
      * 행사의 최대 신청자 수를 변경할 때, 현재 신청자 수보다 낮게 설정하는 경우 예외를 발생시킵니다.
      */
-    public void validateWhenUpdateMaxApplicantCount(int currentApplicants, @Nullable Integer newMaxApplicantCount) {
+    public void validateWhenUpdateMaxApplicantCount(long currentApplicants, @Nullable Integer newMaxApplicantCount) {
         if (newMaxApplicantCount == null) { // 인원 제한을 없애는 경우 항상 허용
             return;
         }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
@@ -1,0 +1,24 @@
+package com.gdschongik.gdsc.domain.event.domain.service;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+
+import com.gdschongik.gdsc.global.annotation.DomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import jakarta.annotation.Nullable;
+
+@DomainService
+public class EventDomainService {
+
+    /**
+     * 행사의 최대 신청자 수를 변경할 때, 현재 신청자 수보다 낮게 설정하는 경우 예외를 발생시킵니다.
+     */
+    public void validateWhenUpdateMaxApplicantCount(int currentApplicants, @Nullable Integer newMaxApplicantCount) {
+        if (newMaxApplicantCount == null) { // 인원 제한을 없애는 경우 항상 허용
+            return;
+        }
+
+        if (currentApplicants > newMaxApplicantCount) {
+            throw new CustomException(EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
@@ -12,12 +12,12 @@ public class EventDomainService {
     /**
      * 행사의 최대 신청자 수를 변경할 때, 현재 신청자 수보다 낮게 설정하는 경우 예외를 발생시킵니다.
      */
-    public void validateWhenUpdateMaxApplicantCount(long currentApplicants, @Nullable Integer newMaxApplicantCount) {
+    public void validateUpdateMaxApplicantCount(long currentApplicantCount, @Nullable Integer newMaxApplicantCount) {
         if (newMaxApplicantCount == null) { // 인원 제한을 없애는 경우 항상 허용
             return;
         }
 
-        if (currentApplicants > newMaxApplicantCount) {
+        if (currentApplicantCount > newMaxApplicantCount) {
             throw new CustomException(EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID);
         }
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
@@ -1,9 +1,10 @@
-package com.gdschongik.gdsc.domain.event.domain;
+package com.gdschongik.gdsc.domain.event.domain.service;
 
 import static com.gdschongik.gdsc.domain.event.domain.AfterPartyApplicationStatus.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.event.domain.*;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.annotation.DomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -201,6 +201,7 @@ public enum ErrorCode {
     EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED(CONFLICT, "뒤풀이가 비활성화된 이벤트에 뒤풀이 신청을 할 수 없습니다."),
     EVENT_NOT_APPLICABLE_MEMBER_INFO_NOT_SATISFIED(CONFLICT, "기본 회원정보 작성이 완료되지 않은 회원은 이벤트에 신청할 수 없습니다."),
     EVENT_NOT_APPLICABLE_MEMBER_INFO_SATISFIED(CONFLICT, "기본 회원정보가 작성된 회원의 학번으로는 비회원 신청을 할 수 없습니다."),
+    EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID(CONFLICT, "최대 신청자 수를 현재 신청자 수보다 적게 변경할 수 없습니다."),
     PARTICIPATION_NOT_READABLE_AFTER_PARTY_DISABLED(BAD_REQUEST, "뒤풀이가 비활성화된 이벤트의 참여정보는 조회할 수 없습니다."),
     PARTICIPATION_NOT_DELETABLE_INVALID_IDS(BAD_REQUEST, "존재하지 않거나 중복된 참여 정보 ID가 포함되어 있습니다."),
     PARTICIPANT_NOT_CREATABLE_INFO_NOT_SATISFIED(

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
@@ -1,0 +1,50 @@
+package com.gdschongik.gdsc.domain.event.domain;
+
+import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.gdschongik.gdsc.domain.event.domain.service.EventDomainService;
+import com.gdschongik.gdsc.global.exception.CustomException;
+import org.junit.jupiter.api.Test;
+
+public class EventDomainServiceTest {
+
+    EventDomainService eventDomainService = new EventDomainService();
+
+    @Test
+    void 현재_신청인원보다_최대_신청인원을_많게_변경하는_경우_성공한다() {
+        // given
+        int currentApplicants = 10;
+        Integer newMaxApplicantCount = 15;
+
+        // when & then
+        assertThatCode(() ->
+                        eventDomainService.validateWhenUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 최대_신청인원_제한을_없애는_경우_성공한다() {
+        // given
+        int currentApplicants = 10;
+        Integer newMaxApplicantCount = null;
+
+        // when & then
+        assertThatCode(() ->
+                        eventDomainService.validateWhenUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 현재_신청인원보다_최대_신청인원을_적게_변경하는_경우_실패한다() {
+        // given
+        int currentApplicants = 10;
+        Integer newMaxApplicantCount = 5;
+
+        // when & then
+        assertThatThrownBy(() ->
+                        eventDomainService.validateWhenUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID.getMessage());
+    }
+}

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
@@ -5,46 +5,47 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.event.domain.service.EventDomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class EventDomainServiceTest {
 
     EventDomainService eventDomainService = new EventDomainService();
 
-    @Test
-    void 현재_신청인원보다_최대_신청인원을_많게_변경하는_경우_성공한다() {
-        // given
-        int currentApplicants = 10;
-        Integer newMaxApplicantCount = 15;
+    @Nested
+    class 이벤트를_수정할_때 {
+        @Test
+        void 현재_신청인원보다_최대_신청인원을_많게_변경하는_경우_성공한다() {
+            // given
+            int currentApplicants = 10;
+            Integer newMaxApplicantCount = 15;
 
-        // when & then
-        assertThatCode(() ->
-                        eventDomainService.validateUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
-                .doesNotThrowAnyException();
-    }
+            // when & then
+            assertThatCode(() -> eventDomainService.validateUpdate(currentApplicants, newMaxApplicantCount, 0, 0))
+                    .doesNotThrowAnyException();
+        }
 
-    @Test
-    void 최대_신청인원_제한을_없애는_경우_성공한다() {
-        // given
-        int currentApplicants = 10;
-        Integer newMaxApplicantCount = null;
+        @Test
+        void 최대_신청인원_제한을_없애는_경우_성공한다() {
+            // given
+            int currentApplicants = 10;
+            Integer newMaxApplicantCount = null;
 
-        // when & then
-        assertThatCode(() ->
-                        eventDomainService.validateUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
-                .doesNotThrowAnyException();
-    }
+            // when & then
+            assertThatCode(() -> eventDomainService.validateUpdate(currentApplicants, newMaxApplicantCount, 0, 0))
+                    .doesNotThrowAnyException();
+        }
 
-    @Test
-    void 현재_신청인원보다_최대_신청인원을_적게_변경하는_경우_실패한다() {
-        // given
-        int currentApplicants = 10;
-        Integer newMaxApplicantCount = 5;
+        @Test
+        void 현재_신청인원보다_최대_신청인원을_적게_변경하는_경우_실패한다() {
+            // given
+            int currentApplicants = 10;
+            Integer newMaxApplicantCount = 5;
 
-        // when & then
-        assertThatThrownBy(() ->
-                        eventDomainService.validateUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID.getMessage());
+            // when & then
+            assertThatThrownBy(() -> eventDomainService.validateUpdate(currentApplicants, newMaxApplicantCount, 0, 0))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID.getMessage());
+        }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
@@ -1,49 +1,116 @@
 package com.gdschongik.gdsc.domain.event.domain;
 
+import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.event.domain.service.EventDomainService;
 import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.FixtureHelper;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class EventDomainServiceTest {
 
     EventDomainService eventDomainService = new EventDomainService();
+    FixtureHelper fixtureHelper = new FixtureHelper();
 
     @Nested
     class 이벤트를_수정할_때 {
         @Test
         void 현재_신청인원보다_최대_신청인원을_많게_변경하는_경우_성공한다() {
             // given
-            int currentApplicants = 10;
-            Integer newMaxApplicantCount = 15;
+            Event event = fixtureHelper.createEvent(
+                    1L,
+                    REGULAR_ROLE_ONLY_STATUS,
+                    AFTER_PARTY_STATUS,
+                    PRE_PAYMENT_STATUS,
+                    POST_PAYMENT_STATUS,
+                    RSVP_QUESTION_STATUS);
 
-            // when & then
-            assertThatCode(() -> eventDomainService.validateUpdate(currentApplicants, newMaxApplicantCount, 0, 0))
-                    .doesNotThrowAnyException();
+            Integer newMainEventMaxApplicantCount = 15;
+            Integer newAfterPartyMaxApplicantCount = 15;
+            long currentMainEventApplicants = 10;
+            long currentAfterPartyApplicants = 10;
+
+            // when
+            eventDomainService.update(
+                    event,
+                    EVENT_NAME,
+                    VENUE,
+                    EVENT_START_AT,
+                    APPLICATION_DESCRIPTION,
+                    EVENT_APPLICATION_PERIOD,
+                    newMainEventMaxApplicantCount,
+                    newAfterPartyMaxApplicantCount,
+                    currentMainEventApplicants,
+                    currentAfterPartyApplicants);
+
+            // then
+            assertThat(event.getMainEventMaxApplicantCount()).isEqualTo(newMainEventMaxApplicantCount);
         }
 
         @Test
         void 최대_신청인원_제한을_없애는_경우_성공한다() {
             // given
-            int currentApplicants = 10;
-            Integer newMaxApplicantCount = null;
+            Event event = fixtureHelper.createEvent(
+                    1L,
+                    REGULAR_ROLE_ONLY_STATUS,
+                    AFTER_PARTY_STATUS,
+                    PRE_PAYMENT_STATUS,
+                    POST_PAYMENT_STATUS,
+                    RSVP_QUESTION_STATUS);
 
-            // when & then
-            assertThatCode(() -> eventDomainService.validateUpdate(currentApplicants, newMaxApplicantCount, 0, 0))
-                    .doesNotThrowAnyException();
+            Integer newMainEventMaxApplicantCount = null;
+            Integer newAfterPartyMaxApplicantCount = null;
+            long currentMainEventApplicants = 10;
+            long currentAfterPartyApplicants = 10;
+
+            // when
+            eventDomainService.update(
+                    event,
+                    EVENT_NAME,
+                    VENUE,
+                    EVENT_START_AT,
+                    APPLICATION_DESCRIPTION,
+                    EVENT_APPLICATION_PERIOD,
+                    newMainEventMaxApplicantCount,
+                    newAfterPartyMaxApplicantCount,
+                    currentMainEventApplicants,
+                    currentAfterPartyApplicants);
+
+            // then
+            assertThat(event.getMainEventMaxApplicantCount()).isNull();
         }
 
         @Test
         void 현재_신청인원보다_최대_신청인원을_적게_변경하는_경우_실패한다() {
             // given
-            int currentApplicants = 10;
-            Integer newMaxApplicantCount = 5;
+            Event event = fixtureHelper.createEvent(
+                    1L,
+                    REGULAR_ROLE_ONLY_STATUS,
+                    AFTER_PARTY_STATUS,
+                    PRE_PAYMENT_STATUS,
+                    POST_PAYMENT_STATUS,
+                    RSVP_QUESTION_STATUS);
+
+            Integer newMainEventMaxApplicantCount = 0;
+            Integer newAfterPartyMaxApplicantCount = 0;
+            long currentMainEventApplicants = 10;
+            long currentAfterPartyApplicants = 10;
 
             // when & then
-            assertThatThrownBy(() -> eventDomainService.validateUpdate(currentApplicants, newMaxApplicantCount, 0, 0))
+            assertThatThrownBy(() -> eventDomainService.update(
+                            event,
+                            EVENT_NAME,
+                            VENUE,
+                            EVENT_START_AT,
+                            APPLICATION_DESCRIPTION,
+                            EVENT_APPLICATION_PERIOD,
+                            newMainEventMaxApplicantCount,
+                            newAfterPartyMaxApplicantCount,
+                            currentMainEventApplicants,
+                            currentAfterPartyApplicants))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID.getMessage());
         }

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
@@ -19,7 +19,7 @@ public class EventDomainServiceTest {
 
         // when & then
         assertThatCode(() ->
-                        eventDomainService.validateWhenUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
+                        eventDomainService.validateUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
                 .doesNotThrowAnyException();
     }
 
@@ -31,7 +31,7 @@ public class EventDomainServiceTest {
 
         // when & then
         assertThatCode(() ->
-                        eventDomainService.validateWhenUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
+                        eventDomainService.validateUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
                 .doesNotThrowAnyException();
     }
 
@@ -43,7 +43,7 @@ public class EventDomainServiceTest {
 
         // when & then
         assertThatThrownBy(() ->
-                        eventDomainService.validateWhenUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
+                        eventDomainService.validateUpdateMaxApplicantCount(currentApplicants, newMaxApplicantCount))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID.getMessage());
     }

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -5,6 +5,7 @@ import static com.gdschongik.gdsc.global.common.constant.MemberConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.domain.event.domain.service.EventParticipationDomainService;
 import com.gdschongik.gdsc.domain.member.domain.Member;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.FixtureHelper;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1189

## 📌 작업 내용 및 특이사항
혁님과 논의해본 결과 진행 장소가 중간에 변경되거나, 진행 장소가 늦게 확정되는 경우 고려
- 신청 인원 제한이 변경 가능해야한다.
- 특히 처음엔 제한이 없다가 중간에 생기는 경우가 있을 수 있다.

단순히 현재 제한 인원보다 줄어드는 경우를 막는 경우 -> 처음에 신청 제한 없다가 중간에 생기는 경우 지원 불가능
현재 신청 인원을 확인 후 그것보다 적게 줄이는 경우에 비허용하는 걸로 구현해야함

동시성 이슈 문제는 나중에 이벤트 참여 신청시 인원 제한 있는 경우 선착순 허용 구현할 때 같이 해결해야할 듯 함

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 이벤트 수정 시 현재 신청자 수보다 최대 신청자 수를 더 작게 설정할 수 없도록 서버단 검증 로직을 도입했습니다.
- Improvements
  - 메인 이벤트·애프터파티 신청자 수를 집계해 검증에 활용하도록 집계 기능과 업데이트 흐름을 보강했습니다.
  - 도메인 수준에서 업데이트 검증을 중앙화해 일관성 및 유지보수성을 향상했습니다.
- Tests
  - 정상 및 예외(최대값 미만) 케이스를 검증하는 단위 테스트를 추가했습니다.
- Other
  - 관련 오류 코드가 추가되어 명확한 오류 메시지를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->