### PR TITLE
refactor: 이벤트에 유의사항 확인 질문 사용 여부 필드 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -53,6 +53,7 @@ public class EventService {
                 request.prePaymentStatus(),
                 request.postPaymentStatus(),
                 request.rsvpQuestionStatus(),
+                request.noticeConfirmQuestionStatus(),
                 request.mainEventMaxApplicantCount(),
                 request.afterPartyMaxApplicantCount());
         eventRepository.save(event);

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
@@ -78,6 +78,10 @@ public class Event extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UsageStatus rsvpQuestionStatus;
 
+    @Comment("[메타] 유의사항 확인 질문 활성화 상태")
+    @Enumerated(EnumType.STRING)
+    private UsageStatus noticeConfirmQuestionStatus;
+
     @Comment("본행사 최대 신청 가능 인원")
     private Integer mainEventMaxApplicantCount;
 
@@ -96,6 +100,7 @@ public class Event extends BaseEntity {
             UsageStatus prePaymentStatus,
             UsageStatus postPaymentStatus,
             UsageStatus rsvpQuestionStatus,
+            UsageStatus noticeConfirmQuestionStatus,
             Integer mainEventMaxApplicantCount,
             Integer afterPartyMaxApplicantCount) {
         this.name = name;
@@ -108,6 +113,7 @@ public class Event extends BaseEntity {
         this.prePaymentStatus = prePaymentStatus;
         this.postPaymentStatus = postPaymentStatus;
         this.rsvpQuestionStatus = rsvpQuestionStatus;
+        this.noticeConfirmQuestionStatus = noticeConfirmQuestionStatus;
         this.mainEventMaxApplicantCount = mainEventMaxApplicantCount;
         this.afterPartyMaxApplicantCount = afterPartyMaxApplicantCount;
     }
@@ -124,6 +130,7 @@ public class Event extends BaseEntity {
             UsageStatus prePaymentStatus,
             UsageStatus postPaymentStatus,
             UsageStatus rsvpQuestionStatus,
+            UsageStatus noticeConfirmQuestionStatus,
             Integer mainEventMaxApplicantCount,
             Integer afterPartyMaxApplicantCount) {
         validatePaymentDisabledWhenAfterPartyDisabled(afterPartyStatus, prePaymentStatus, postPaymentStatus);
@@ -140,6 +147,7 @@ public class Event extends BaseEntity {
                 .prePaymentStatus(prePaymentStatus)
                 .postPaymentStatus(postPaymentStatus)
                 .rsvpQuestionStatus(rsvpQuestionStatus)
+                .noticeConfirmQuestionStatus(noticeConfirmQuestionStatus)
                 .mainEventMaxApplicantCount(mainEventMaxApplicantCount)
                 .afterPartyMaxApplicantCount(afterPartyMaxApplicantCount)
                 .build();

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/dto/EventDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/dto/EventDto.java
@@ -17,6 +17,7 @@ public record EventDto(
         UsageStatus prePaymentStatus,
         UsageStatus postPaymentStatus,
         UsageStatus rsvpQuestionStatus,
+        UsageStatus noticeConfirmQuestionStatus,
         Integer mainEventMaxApplicantCount,
         Integer afterPartyMaxApplicantCount) {
 
@@ -33,6 +34,7 @@ public record EventDto(
                 event.getPrePaymentStatus(),
                 event.getPostPaymentStatus(),
                 event.getRsvpQuestionStatus(),
+                event.getNoticeConfirmQuestionStatus(),
                 event.getMainEventMaxApplicantCount(),
                 event.getAfterPartyMaxApplicantCount());
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
@@ -18,5 +18,6 @@ public record EventCreateRequest(
         @NotNull UsageStatus prePaymentStatus,
         @NotNull UsageStatus postPaymentStatus,
         @NotNull UsageStatus rsvpQuestionStatus,
+        @NotNull UsageStatus noticeConfirmQuestionStatus,
         @Positive Integer mainEventMaxApplicantCount,
         @Positive Integer afterPartyMaxApplicantCount) {}

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
@@ -524,6 +524,7 @@ class EventParticipationServiceTest extends IntegrationTest {
                 DISABLED,
                 DISABLED,
                 RSVP_QUESTION_STATUS,
+                NOTICE_CONFIRM_QUESTION_STATUS,
                 MAIN_EVENT_MAX_APPLICATION_COUNT,
                 AFTER_PARTY_MAX_APPLICATION_COUNT);
         return eventRepository.save(event);

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
@@ -35,6 +35,7 @@ public class EventServiceTest extends IntegrationTest {
                     PRE_PAYMENT_STATUS,
                     POST_PAYMENT_STATUS,
                     RSVP_QUESTION_STATUS,
+                    NOTICE_CONFIRM_QUESTION_STATUS,
                     MAIN_EVENT_MAX_APPLICATION_COUNT,
                     AFTER_PARTY_MAX_APPLICATION_COUNT);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/AfterPartyAttendanceStatusTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/AfterPartyAttendanceStatusTest.java
@@ -18,7 +18,6 @@ public class AfterPartyAttendanceStatusTest {
                 UsageStatus.DISABLED,
                 UsageStatus.DISABLED, // 뒤풀이 비활성화
                 UsageStatus.DISABLED,
-                UsageStatus.DISABLED,
                 UsageStatus.DISABLED);
 
         // when
@@ -35,7 +34,6 @@ public class AfterPartyAttendanceStatusTest {
                 1L,
                 UsageStatus.DISABLED,
                 UsageStatus.ENABLED, // 뒤풀이 활성화
-                UsageStatus.DISABLED,
                 UsageStatus.DISABLED,
                 UsageStatus.DISABLED);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
@@ -21,12 +21,7 @@ public class EventDomainServiceTest {
         void 현재_신청인원보다_최대_신청인원을_많게_변경하는_경우_성공한다() {
             // given
             Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
 
             Integer newMainEventMaxApplicantCount = 15;
             Integer newAfterPartyMaxApplicantCount = 15;
@@ -54,12 +49,7 @@ public class EventDomainServiceTest {
         void 최대_신청인원_제한을_없애는_경우_성공한다() {
             // given
             Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
 
             Integer newMainEventMaxApplicantCount = null;
             Integer newAfterPartyMaxApplicantCount = null;
@@ -87,12 +77,7 @@ public class EventDomainServiceTest {
         void 현재_신청인원보다_최대_신청인원을_적게_변경하는_경우_실패한다() {
             // given
             Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
 
             Integer newMainEventMaxApplicantCount = 0;
             Integer newAfterPartyMaxApplicantCount = 0;

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -28,12 +28,7 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             // 신청 기간 (25년 3월 1일 ~ 3월 14일)
             Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
             LocalDateTime invalidDate = LocalDateTime.of(2025, 4, 1, 0, 0);
 
             // when & then
@@ -52,8 +47,7 @@ public class EventParticipationDomainServiceTest {
                     UsageStatus.ENABLED, // 정회원 전용 신청 폼
                     AFTER_PARTY_STATUS,
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -72,8 +66,7 @@ public class EventParticipationDomainServiceTest {
                     REGULAR_ROLE_ONLY_STATUS,
                     UsageStatus.ENABLED, // 뒤풀이 활성화
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -92,8 +85,7 @@ public class EventParticipationDomainServiceTest {
                     REGULAR_ROLE_ONLY_STATUS,
                     UsageStatus.DISABLED, // 뒤풀이 비활성화
                     UsageStatus.DISABLED,
-                    UsageStatus.DISABLED,
-                    RSVP_QUESTION_STATUS);
+                    UsageStatus.DISABLED);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -108,12 +100,7 @@ public class EventParticipationDomainServiceTest {
             Member guestMember = fixtureHelper.createGuestMember(1L); // 기본 정보 미작성
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -133,12 +120,7 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             // 신청 기간 (25년 3월 1일 ~ 3월 14일)
             Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
             LocalDateTime invalidDate = LocalDateTime.of(2025, 4, 1, 0, 0);
 
             // when & then
@@ -158,8 +140,7 @@ public class EventParticipationDomainServiceTest {
                     UsageStatus.ENABLED, // 정회원 전용 신청 폼
                     AFTER_PARTY_STATUS,
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -178,8 +159,7 @@ public class EventParticipationDomainServiceTest {
                     REGULAR_ROLE_ONLY_STATUS,
                     UsageStatus.ENABLED, // 뒤풀이 활성화
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -199,8 +179,7 @@ public class EventParticipationDomainServiceTest {
                     REGULAR_ROLE_ONLY_STATUS,
                     UsageStatus.DISABLED, // 뒤풀이 비활성화
                     UsageStatus.DISABLED,
-                    UsageStatus.DISABLED,
-                    RSVP_QUESTION_STATUS);
+                    UsageStatus.DISABLED);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -216,12 +195,7 @@ public class EventParticipationDomainServiceTest {
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             boolean infoStatusSatisfiedMemberExists = true; // 기본정보가 작성된 회원이 존재함
@@ -246,8 +220,7 @@ public class EventParticipationDomainServiceTest {
                     UsageStatus.ENABLED, // 정회원 전용 신청 폼
                     AFTER_PARTY_STATUS,
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
 
             // when & then
             assertThatThrownBy(() -> domainService.joinOnsiteForRegistered(guestMember, event))
@@ -268,8 +241,7 @@ public class EventParticipationDomainServiceTest {
                     UsageStatus.ENABLED, // 정회원 전용 신청 폼
                     AFTER_PARTY_STATUS,
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
 
             // when & then
             assertThatThrownBy(() -> domainService.joinOnsiteForUnregistered(participant, event, false))
@@ -290,8 +262,7 @@ public class EventParticipationDomainServiceTest {
                     UsageStatus.ENABLED, // 정회원 전용 신청 폼
                     AFTER_PARTY_STATUS,
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
 
             // when & then
             assertThatThrownBy(() -> domainService.applyManualForRegistered(guestMember, event))
@@ -308,8 +279,7 @@ public class EventParticipationDomainServiceTest {
                     REGULAR_ROLE_ONLY_STATUS,
                     UsageStatus.ENABLED, // 뒤풀이 활성화
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
 
             // when
             EventParticipation participation = domainService.applyManualForRegistered(member, eventWithAfterParty);
@@ -328,8 +298,7 @@ public class EventParticipationDomainServiceTest {
                     REGULAR_ROLE_ONLY_STATUS,
                     UsageStatus.DISABLED, // 뒤풀이 비활성화
                     UsageStatus.DISABLED,
-                    UsageStatus.DISABLED,
-                    RSVP_QUESTION_STATUS);
+                    UsageStatus.DISABLED);
 
             // when
             EventParticipation participation = domainService.applyManualForRegistered(member, eventWithoutAfterParty);
@@ -344,12 +313,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Member guestMember = fixtureHelper.createGuestMember(1L); // 기본 정보 미작성
             Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
 
             // when & then
             assertThatThrownBy(() -> domainService.applyManualForRegistered(guestMember, event))
@@ -370,8 +334,7 @@ public class EventParticipationDomainServiceTest {
                     UsageStatus.ENABLED, // 정회원 전용 신청 폼
                     AFTER_PARTY_STATUS,
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
 
             // when & then
             assertThatThrownBy(() -> domainService.applyManualForUnregistered(participant, event, false))
@@ -388,8 +351,7 @@ public class EventParticipationDomainServiceTest {
                     REGULAR_ROLE_ONLY_STATUS,
                     UsageStatus.ENABLED, // 뒤풀이 활성화
                     PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    POST_PAYMENT_STATUS);
 
             // when
             EventParticipation participation =
@@ -409,8 +371,7 @@ public class EventParticipationDomainServiceTest {
                     REGULAR_ROLE_ONLY_STATUS,
                     UsageStatus.DISABLED, // 뒤풀이 비활성화
                     UsageStatus.DISABLED,
-                    UsageStatus.DISABLED,
-                    RSVP_QUESTION_STATUS);
+                    UsageStatus.DISABLED);
 
             // when
             EventParticipation participation =
@@ -426,12 +387,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS);
+                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
 
             boolean infoStatusSatisfiedMemberExists = true; // 기본정보가 작성된 회원이 존재함
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
@@ -32,6 +32,7 @@ public class EventTest {
                             prePaymentStatus,
                             postPaymentStatus,
                             RSVP_QUESTION_STATUS,
+                            NOTICE_CONFIRM_QUESTION_STATUS,
                             MAIN_EVENT_MAX_APPLICATION_COUNT,
                             AFTER_PARTY_MAX_APPLICATION_COUNT))
                     .isInstanceOf(CustomException.class)
@@ -57,6 +58,7 @@ public class EventTest {
                             prePaymentStatus,
                             postPaymentStatus,
                             RSVP_QUESTION_STATUS,
+                            NOTICE_CONFIRM_QUESTION_STATUS,
                             MAIN_EVENT_MAX_APPLICATION_COUNT,
                             AFTER_PARTY_MAX_APPLICATION_COUNT))
                     .isInstanceOf(CustomException.class)

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/PaymentStatusTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/PaymentStatusTest.java
@@ -18,7 +18,6 @@ public class PaymentStatusTest {
                 UsageStatus.DISABLED,
                 UsageStatus.ENABLED, // 뒤풀이 활성화
                 UsageStatus.ENABLED, // 선입금 활성화
-                UsageStatus.DISABLED,
                 UsageStatus.DISABLED);
 
         // when
@@ -36,7 +35,6 @@ public class PaymentStatusTest {
                 UsageStatus.DISABLED,
                 UsageStatus.ENABLED, // 뒤풀이 활성화
                 UsageStatus.DISABLED, // 선입금 비활성화
-                UsageStatus.DISABLED,
                 UsageStatus.DISABLED);
 
         // when
@@ -54,8 +52,7 @@ public class PaymentStatusTest {
                 UsageStatus.DISABLED,
                 UsageStatus.ENABLED, // 뒤풀이 활성화
                 UsageStatus.DISABLED,
-                UsageStatus.ENABLED, // 후정산 활성화
-                UsageStatus.DISABLED);
+                UsageStatus.ENABLED); // 후정산 활성화
 
         // when
         PaymentStatus status = PaymentStatus.getInitialPostPaymentStatus(event);
@@ -72,8 +69,7 @@ public class PaymentStatusTest {
                 UsageStatus.DISABLED,
                 UsageStatus.ENABLED, // 뒤풀이 활성화
                 UsageStatus.DISABLED,
-                UsageStatus.DISABLED, // 후정산 비활성화
-                UsageStatus.DISABLED);
+                UsageStatus.DISABLED); // 후정산 비활성화
 
         // when
         PaymentStatus status = PaymentStatus.getInitialPostPaymentStatus(event);

--- a/src/test/java/com/gdschongik/gdsc/global/common/constant/EventConstant.java
+++ b/src/test/java/com/gdschongik/gdsc/global/common/constant/EventConstant.java
@@ -22,6 +22,7 @@ public class EventConstant {
     public static final UsageStatus PRE_PAYMENT_STATUS = UsageStatus.ENABLED;
     public static final UsageStatus POST_PAYMENT_STATUS = UsageStatus.DISABLED;
     public static final UsageStatus RSVP_QUESTION_STATUS = UsageStatus.DISABLED;
+    public static final UsageStatus NOTICE_CONFIRM_QUESTION_STATUS = UsageStatus.DISABLED;
     public static final int MAIN_EVENT_MAX_APPLICATION_COUNT = 100;
     public static final int AFTER_PARTY_MAX_APPLICATION_COUNT = 100;
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -170,8 +170,7 @@ public class FixtureHelper {
             UsageStatus regularRoleOnlyStatus,
             UsageStatus afterPartyStatus,
             UsageStatus prePaymentStatus,
-            UsageStatus postPaymentStatus,
-            UsageStatus rsvpQuestionStatus) {
+            UsageStatus postPaymentStatus) {
         Event event = Event.create(
                 EVENT_NAME,
                 VENUE,
@@ -182,7 +181,8 @@ public class FixtureHelper {
                 afterPartyStatus,
                 prePaymentStatus,
                 postPaymentStatus,
-                rsvpQuestionStatus,
+                RSVP_QUESTION_STATUS,
+                NOTICE_CONFIRM_QUESTION_STATUS,
                 MAIN_EVENT_MAX_APPLICATION_COUNT,
                 AFTER_PARTY_MAX_APPLICATION_COUNT);
 

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -350,6 +350,7 @@ public abstract class IntegrationTest {
                 PRE_PAYMENT_STATUS,
                 POST_PAYMENT_STATUS,
                 RSVP_QUESTION_STATUS,
+                NOTICE_CONFIRM_QUESTION_STATUS,
                 MAIN_EVENT_MAX_APPLICATION_COUNT,
                 AFTER_PARTY_MAX_APPLICATION_COUNT);
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1188

## 📌 작업 내용 및 특이사항
<img width="588" height="648" alt="스크린샷 2025-09-08 오후 9 31 19" src="https://github.com/user-attachments/assets/63f67f95-6864-4161-b7f4-8f7650a50001" />

- 유의사항 질문이 필수가 아님에 따라 RSVP 질문 여부처럼 메타 필드 추가
- FixtureHelper의 createEvent() 메서드에서 검증에 사용되지 않는 RSVP 질문 여부가 파라미터로 들어가있어 제거


## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 이벤트에 ‘유의사항 확인 질문’ 활성화 여부가 추가되었습니다. 이벤트 생성 시 반드시 설정해야 하며, 신청 양식에 안내/유의사항 확인 항목을 표시할 수 있습니다. 기존 신청 흐름, 인원 제한 등 다른 설정에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->