### PR TITLE
feat: 이벤트 참여 도메인 서비스 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
@@ -14,13 +14,12 @@ import java.time.LocalDateTime;
 public class EventParticipationDomainService {
 
     /**
-     * 회원이 온라인을 통해 이벤트에 참여 신청하는 메서드입니다.
+     * 기본 정보 입력을 마친 회원이 온라인을 통해 이벤트에 참여 신청하는 메서드입니다.
      */
     public EventParticipation applyEventForRegistered(
             Member member, AfterPartyApplicationStatus afterPartyApplicationStatus, Event event, LocalDateTime now) {
         validateEventApplicationPeriod(event, now);
         validateMemberWhenOnlyRegularRoleAllowed(event, member);
-        validateMemberBasicInfoSatisfied(member);
         validateAfterPartyApplicationStatus(event, afterPartyApplicationStatus);
 
         AfterPartyAttendanceStatus afterPartyAttendanceStatus = AfterPartyAttendanceStatus.getInitialStatus(event);
@@ -37,17 +36,15 @@ public class EventParticipationDomainService {
     }
 
     /**
-     * 비회원이 온라인을 통해 이벤트에 참여 신청하는 메서드입니다.
+     * 기본 정보 입력을 마치지 않은 회원이나 비회원이 온라인을 통해 이벤트에 참여 신청하는 메서드입니다.
      */
     public EventParticipation applyEventForUnregistered(
             Participant participant,
             AfterPartyApplicationStatus afterPartyApplicationStatus,
             Event event,
-            LocalDateTime now,
-            boolean infoStatusSatisfiedMemberExists) {
+            LocalDateTime now) {
         validateEventApplicationPeriod(event, now);
         validateNotRegularRoleAllowed(event);
-        validateMemberInfoForUnregistered(infoStatusSatisfiedMemberExists);
         validateAfterPartyApplicationStatus(event, afterPartyApplicationStatus);
 
         AfterPartyAttendanceStatus afterPartyAttendanceStatus = AfterPartyAttendanceStatus.getInitialStatus(event);

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -93,21 +93,6 @@ public class EventParticipationDomainServiceTest {
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED.getMessage());
         }
-
-        @Test
-        void 기본_정보가_작성되지_않은_회원이_신청하면_실패한다() {
-            // given
-            Member guestMember = fixtureHelper.createGuestMember(1L); // 기본 정보 미작성
-            AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
-            LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
-
-            // when & then
-            assertThatThrownBy(() -> domainService.applyEventForRegistered(guestMember, status, event, now))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLICABLE_MEMBER_INFO_NOT_SATISFIED.getMessage());
-        }
     }
 
     @Nested
@@ -124,8 +109,7 @@ public class EventParticipationDomainServiceTest {
             LocalDateTime invalidDate = LocalDateTime.of(2025, 4, 1, 0, 0);
 
             // when & then
-            assertThatThrownBy(() ->
-                            domainService.applyEventForUnregistered(participant, status, event, invalidDate, false))
+            assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, status, event, invalidDate))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_APPLICATION_PERIOD_INVALID.getMessage());
         }
@@ -144,7 +128,7 @@ public class EventParticipationDomainServiceTest {
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
-            assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, status, event, now, false))
+            assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, status, event, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE.getMessage());
         }
@@ -163,8 +147,7 @@ public class EventParticipationDomainServiceTest {
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
-            assertThatThrownBy(
-                            () -> domainService.applyEventForUnregistered(participant, noneStatus, event, now, false))
+            assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, noneStatus, event, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_AFTER_PARTY_NONE.getMessage());
         }
@@ -183,28 +166,9 @@ public class EventParticipationDomainServiceTest {
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
-            assertThatThrownBy(() ->
-                            domainService.applyEventForUnregistered(participant, appliedStatus, event, now, false))
+            assertThatThrownBy(() -> domainService.applyEventForUnregistered(participant, appliedStatus, event, now))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED.getMessage());
-        }
-
-        @Test
-        void 기본_정보가_작성된_학번으로_신청하면_실패한다() {
-            // given
-            Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
-            AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
-            LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
-
-            boolean infoStatusSatisfiedMemberExists = true; // 기본정보가 작성된 회원이 존재함
-
-            // when & then
-            assertThatThrownBy(() -> domainService.applyEventForUnregistered(
-                            participant, status, event, now, infoStatusSatisfiedMemberExists))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(EVENT_NOT_APPLICABLE_MEMBER_INFO_SATISFIED.getMessage());
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1196

## 📌 작업 내용 및 특이사항
- 다 뒤집어 엎어야 하는 줄 알았는데 생각해보니 같은 api를 타고 서비스단까지 오고, infoSatisfied에 따라 분기를 치면 되므로 기존 메서드에서 infoSatisfied에 대한 검증만 제거하면 될 것 같아요.
- 제가 놓치고 있는 부분 있으면 코멘트 부탁드립니다~

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능/개선
  - 온라인 행사 신청의 검증 조건을 완화하여, 일부 회원/비회원의 신청이 이전보다 원활해졌습니다.
- 버그 수정
  - 불필요한 기본 정보 관련 제약으로 특정 상황에서 온라인 신청이 차단되던 문제를 해소했습니다.
- 문서
  - 온라인 신청 가능 대상에 대한 안내를 최신 정책에 맞춰 정비했습니다.
- 리팩터링
  - 비회원 온라인 신청 흐름을 단순화하여 불필요한 입력/판단 요소를 제거했습니다.
- 테스트
  - 변경된 신청 조건에 맞게 테스트 케이스를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->