### PR TITLE
fix: 이벤트 참여 도메인 유니크 제약 수정

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventParticipation.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/EventParticipation.java
@@ -28,7 +28,7 @@ import org.hibernate.annotations.Comment;
 @Entity
 @Table(
         name = "event_participation",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"event_id", "member_id"})})
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"event_id", "student_id"})})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventParticipation extends BaseEntity {
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1194

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 이벤트 참가 중복 판정 기준을 회원 ID에서 학생 ID로 변경하여 동일 학생의 중복 신청을 정확히 차단합니다.
  * 드물게 발생하던 중복 신청 허용/거부 불일치 문제를 해소하고 신청 처리 신뢰성을 향상합니다.
  * 앞으로는 학생 단위로 중복이 판별되어 신청 시 알림/에러가 더 일관되게 표시되며, 관리 화면에서도 중복 생성이 방지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->