### PR TITLE
feat: 이벤트 폼 제출 서비스를 정책에 따라 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/ParticipantEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/ParticipantEventParticipationController.java
@@ -1,7 +1,7 @@
 package com.gdschongik.gdsc.domain.event.api;
 
 import com.gdschongik.gdsc.domain.event.application.EventParticipationService;
-import com.gdschongik.gdsc.domain.event.dto.request.EventApplyRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventApplyOnlineRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,8 +22,8 @@ public class ParticipantEventParticipationController {
 
     @Operation(summary = "이벤트 참여 신청 폼 제출", description = "이벤트 참여 신청 폼을 제출합니다.")
     @PostMapping("/apply")
-    public ResponseEntity<Void> applyEventParticipation(@Valid @RequestBody EventApplyRequest request) {
-        eventParticipationService.applyEventParticipation(request);
+    public ResponseEntity<Void> applyEventParticipation(@Valid @RequestBody EventApplyOnlineRequest request) {
+        eventParticipationService.applyOnline(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
@@ -15,7 +15,7 @@ import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyAttendRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyStatusUpdateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyStatusesUpdateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyUpdateTarget;
-import com.gdschongik.gdsc.domain.event.dto.request.EventApplyRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventApplyOnlineRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventManualApplyRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipationDeleteRequest;
@@ -309,8 +309,7 @@ public class EventParticipationService {
     }
 
     @Transactional
-    public void applyEventParticipation(EventApplyRequest request) {
-        // TODO: 메서드 및 DTO applyOnline으로 이름 변경
+    public void applyOnline(EventApplyOnlineRequest request) {
         Event event =
                 eventRepository.findById(request.eventId()).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
@@ -315,11 +315,12 @@ public class EventParticipationService {
                 eventRepository.findById(request.eventId()).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
 
         Participant participant = request.participant();
-        Member memberByParticipant =
+        Member member =
                 memberRepository.findByStudentId(participant.getStudentId()).orElse(null);
 
         EventParticipation eventParticipation = eventParticipationDomainService.applyOnline(
-                participant, memberByParticipant, request.afterPartyApplicationStatus(), event, now());
+                participant, member, request.afterPartyApplicationStatus(), event, now());
+
         eventParticipationRepository.save(eventParticipation);
 
         log.info(

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
@@ -314,11 +314,11 @@ public class EventParticipationService {
                 eventRepository.findById(request.eventId()).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
 
         Participant participant = request.participant();
-        Member member =
+        Member memberByParticipant =
                 memberRepository.findByStudentId(participant.getStudentId()).orElse(null);
 
         EventParticipation eventParticipation = eventParticipationDomainService.applyOnline(
-                participant, member, request.afterPartyApplicationStatus(), event, now());
+                participant, memberByParticipant, request.afterPartyApplicationStatus(), event, now());
 
         eventParticipationRepository.save(eventParticipation);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventApplyOnlineRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventApplyOnlineRequest.java
@@ -5,7 +5,7 @@ import com.gdschongik.gdsc.domain.event.domain.Participant;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
-public record EventApplyRequest(
+public record EventApplyOnlineRequest(
         @NotNull @Positive Long eventId,
         @NotNull Participant participant,
         @NotNull AfterPartyApplicationStatus afterPartyApplicationStatus) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1218

## 📌 작업 내용 및 특이사항
- 새로 구현된 도메인 서비스로 변경했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩터링**
  * 이벤트 참가 신청의 요청 형식이 온라인 전용으로 이름이 변경되었습니다(엔드포인트 경로와 응답 동작은 변경 없음).
  * 서비스 호출 명칭이 갱신되어 온라인 신청 흐름을 명확히 구분합니다.

* **스타일**
  * 사소한 공백/서식 정리를 통해 코드 일관성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->