### PR TITLE
feat: 이벤트 생성 API 스펙 변경

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -46,14 +46,8 @@ public class EventService {
                 request.name(),
                 request.venue(),
                 request.startAt(),
-                request.applicationDescription(),
                 request.applicationPeriod(),
                 request.regularRoleOnlyStatus(),
-                request.afterPartyStatus(),
-                request.prePaymentStatus(),
-                request.postPaymentStatus(),
-                request.rsvpQuestionStatus(),
-                request.noticeConfirmQuestionStatus(),
                 request.mainEventMaxApplicantCount(),
                 request.afterPartyMaxApplicantCount());
         eventRepository.save(event);

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
@@ -6,7 +6,6 @@ import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import com.gdschongik.gdsc.domain.common.model.BaseEntity;
 import com.gdschongik.gdsc.domain.common.vo.Period;
 import com.gdschongik.gdsc.domain.event.domain.service.EventDomainService;
-import com.gdschongik.gdsc.global.exception.CustomException;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -123,41 +122,26 @@ public class Event extends BaseEntity {
             String name,
             String venue,
             LocalDateTime startAt,
-            String applicationDescription,
             Period applicationPeriod,
             UsageStatus regularRoleOnlyStatus,
-            UsageStatus afterPartyStatus,
-            UsageStatus prePaymentStatus,
-            UsageStatus postPaymentStatus,
-            UsageStatus rsvpQuestionStatus,
-            UsageStatus noticeConfirmQuestionStatus,
             Integer mainEventMaxApplicantCount,
             Integer afterPartyMaxApplicantCount) {
-        validatePaymentDisabledWhenAfterPartyDisabled(afterPartyStatus, prePaymentStatus, postPaymentStatus);
 
         return Event.builder()
                 .name(name)
                 .venue(venue)
                 .startAt(startAt)
-                .applicationDescription(applicationDescription)
+                .applicationDescription(null)
                 .applicationPeriod(applicationPeriod)
                 .regularRoleOnlyStatus(regularRoleOnlyStatus)
-                .afterPartyStatus(afterPartyStatus)
-                .prePaymentStatus(prePaymentStatus)
-                .postPaymentStatus(postPaymentStatus)
-                .rsvpQuestionStatus(rsvpQuestionStatus)
-                .noticeConfirmQuestionStatus(noticeConfirmQuestionStatus)
+                .afterPartyStatus(ENABLED)
+                .prePaymentStatus(DISABLED)
+                .postPaymentStatus(DISABLED)
+                .rsvpQuestionStatus(DISABLED)
+                .noticeConfirmQuestionStatus(DISABLED)
                 .mainEventMaxApplicantCount(mainEventMaxApplicantCount)
                 .afterPartyMaxApplicantCount(afterPartyMaxApplicantCount)
                 .build();
-    }
-
-    // 검증 메서드
-    private static void validatePaymentDisabledWhenAfterPartyDisabled(
-            UsageStatus afterPartyStatus, UsageStatus prePaymentStatus, UsageStatus postPaymentStatus) {
-        if (afterPartyStatus == DISABLED && (prePaymentStatus == ENABLED || postPaymentStatus == ENABLED)) {
-            throw new CustomException(EVENT_NOT_CREATABLE_PAYMENT_ENABLED);
-        }
     }
 
     // 데이터 조회 메서드

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventCreateRequest.java
@@ -12,13 +12,7 @@ public record EventCreateRequest(
         @NotBlank String name,
         String venue,
         @NotNull LocalDateTime startAt,
-        @NotBlank String applicationDescription,
         @NotNull Period applicationPeriod,
         @NotNull UsageStatus regularRoleOnlyStatus,
-        @NotNull UsageStatus afterPartyStatus,
-        @NotNull UsageStatus prePaymentStatus,
-        @NotNull UsageStatus postPaymentStatus,
-        @NotNull UsageStatus rsvpQuestionStatus,
-        @NotNull UsageStatus noticeConfirmQuestionStatus,
         @Positive @Schema(description = "본 행사 최대 신청 가능 인원. 제한 없음은 null을 입력합니다.") Integer mainEventMaxApplicantCount,
         @Positive @Schema(description = "뒤풀이 최대 신청 가능 인원. 제한 없음은 null을 입력합니다.") Integer afterPartyMaxApplicantCount) {}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -194,7 +194,6 @@ public enum ErrorCode {
 
     // Event
     EVENT_NOT_FOUND(NOT_FOUND, "존재하지 않는 이벤트입니다."),
-    EVENT_NOT_CREATABLE_PAYMENT_ENABLED(CONFLICT, "뒤풀이 상태가 비활성화된 경우, 선입금 및 후정산 상태도 비활성화 되어야 합니다."),
     EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE(CONFLICT, "정회원이 아닌 회원은 이벤트에 신청할 수 없습니다."),
     EVENT_NOT_APPLICABLE_APPLICATION_PERIOD_INVALID(CONFLICT, "이벤트 신청 기간이 아닙니다."),
     EVENT_NOT_APPLICABLE_AFTER_PARTY_NONE(CONFLICT, "뒤풀이가 활성화된 이벤트는 뒤풀이 신청 여부를 NONE으로 설정할 수 없습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
@@ -1063,16 +1063,12 @@ class EventParticipationServiceTest extends IntegrationTest {
                 EVENT_NAME,
                 VENUE,
                 EVENT_START_AT,
-                APPLICATION_DESCRIPTION,
                 EVENT_APPLICATION_PERIOD,
                 REGULAR_ROLE_ONLY_STATUS,
-                DISABLED,
-                DISABLED,
-                DISABLED,
-                RSVP_QUESTION_STATUS,
-                NOTICE_CONFIRM_QUESTION_STATUS,
                 MAIN_EVENT_MAX_APPLICATION_COUNT,
                 AFTER_PARTY_MAX_APPLICATION_COUNT);
+        // afterParty를 비활성화하기 위해 reflection 사용
+        ReflectionTestUtils.setField(event, "afterPartyStatus", DISABLED);
         return eventRepository.save(event);
     }
 
@@ -1081,14 +1077,8 @@ class EventParticipationServiceTest extends IntegrationTest {
                 name,
                 VENUE,
                 EVENT_START_AT,
-                APPLICATION_DESCRIPTION,
                 EVENT_APPLICATION_PERIOD,
                 REGULAR_ROLE_ONLY_STATUS,
-                AFTER_PARTY_STATUS,
-                PRE_PAYMENT_STATUS,
-                POST_PAYMENT_STATUS,
-                RSVP_QUESTION_STATUS,
-                NOTICE_CONFIRM_QUESTION_STATUS,
                 MAIN_EVENT_MAX_APPLICATION_COUNT,
                 AFTER_PARTY_MAX_APPLICATION_COUNT);
         return eventRepository.save(event);

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
@@ -28,14 +28,8 @@ public class EventServiceTest extends IntegrationTest {
                     EVENT_NAME,
                     VENUE,
                     EVENT_START_AT,
-                    APPLICATION_DESCRIPTION,
                     EVENT_APPLICATION_PERIOD,
                     REGULAR_ROLE_ONLY_STATUS,
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS,
-                    RSVP_QUESTION_STATUS,
-                    NOTICE_CONFIRM_QUESTION_STATUS,
                     MAIN_EVENT_MAX_APPLICATION_COUNT,
                     AFTER_PARTY_MAX_APPLICATION_COUNT);
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/AfterPartyAttendanceStatusTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/AfterPartyAttendanceStatusTest.java
@@ -1,6 +1,5 @@
 package com.gdschongik.gdsc.domain.event.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
 import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.helper.FixtureHelper;
@@ -13,12 +12,7 @@ public class AfterPartyAttendanceStatusTest {
     @Test
     void 뒤풀이가_없는_이벤트는_초기값이_NONE이다() {
         // given
-        Event event = fixtureHelper.createEvent(
-                1L,
-                UsageStatus.DISABLED,
-                UsageStatus.DISABLED, // 뒤풀이 비활성화
-                UsageStatus.DISABLED,
-                UsageStatus.DISABLED);
+        Event event = fixtureHelper.createEventWithoutAfterParty(1L);
 
         // when
         AfterPartyAttendanceStatus status = AfterPartyAttendanceStatus.getInitialStatus(event);
@@ -30,12 +24,7 @@ public class AfterPartyAttendanceStatusTest {
     @Test
     void 뒤풀이가_있는_이벤트는_초기값이_NOT_ATTENDED이다() {
         // given
-        Event event = fixtureHelper.createEvent(
-                1L,
-                UsageStatus.DISABLED,
-                UsageStatus.ENABLED, // 뒤풀이 활성화
-                UsageStatus.DISABLED,
-                UsageStatus.DISABLED);
+        Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED);
 
         // when
         AfterPartyAttendanceStatus status = AfterPartyAttendanceStatus.getInitialStatus(event);

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
@@ -20,8 +20,7 @@ public class EventDomainServiceTest {
         @Test
         void 현재_신청인원보다_최대_신청인원을_많게_변경하는_경우_성공한다() {
             // given
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
 
             Integer newMainEventMaxApplicantCount = 15;
             Integer newAfterPartyMaxApplicantCount = 15;
@@ -48,8 +47,7 @@ public class EventDomainServiceTest {
         @Test
         void 최대_신청인원_제한을_없애는_경우_성공한다() {
             // given
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
 
             Integer newMainEventMaxApplicantCount = null;
             Integer newAfterPartyMaxApplicantCount = null;
@@ -76,8 +74,7 @@ public class EventDomainServiceTest {
         @Test
         void 현재_신청인원보다_최대_신청인원을_적게_변경하는_경우_실패한다() {
             // given
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
 
             Integer newMainEventMaxApplicantCount = 0;
             Integer newAfterPartyMaxApplicantCount = 0;

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -28,8 +28,7 @@ public class EventParticipationDomainServiceTest {
             Member member = fixtureHelper.createRegularMember(1L);
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             // 신청 기간 (25년 3월 1일 ~ 3월 14일)
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
             LocalDateTime invalidDate = LocalDateTime.of(2025, 4, 1, 0, 0);
 
             // when & then
@@ -43,12 +42,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Member guestMember = fixtureHelper.createGuestMember(1L);
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.ENABLED, // 정회원 전용 신청 폼
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용 신청 폼
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -62,12 +56,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Member member = fixtureHelper.createRegularMember(1L);
             AfterPartyApplicationStatus noneStatus = AfterPartyApplicationStatus.NONE;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.ENABLED, // 뒤풀이 활성화
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -81,12 +70,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Member member = fixtureHelper.createRegularMember(1L);
             AfterPartyApplicationStatus appliedStatus = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.DISABLED, // 뒤풀이 비활성화
-                    UsageStatus.DISABLED,
-                    UsageStatus.DISABLED);
+            Event event = fixtureHelper.createEventWithoutAfterParty(1L);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -106,8 +90,7 @@ public class EventParticipationDomainServiceTest {
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             // 신청 기간 (25년 3월 1일 ~ 3월 14일)
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
             LocalDateTime invalidDate = LocalDateTime.of(2025, 4, 1, 0, 0);
 
             // when & then
@@ -121,12 +104,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.ENABLED, // 정회원 전용 신청 폼
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용 신청 폼
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -140,12 +118,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             AfterPartyApplicationStatus noneStatus = AfterPartyApplicationStatus.NONE;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.ENABLED, // 뒤풀이 활성화
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -159,12 +132,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             AfterPartyApplicationStatus appliedStatus = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.DISABLED, // 뒤풀이 비활성화
-                    UsageStatus.DISABLED,
-                    UsageStatus.DISABLED);
+            Event event = fixtureHelper.createEventWithoutAfterParty(1L);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -182,12 +150,7 @@ public class EventParticipationDomainServiceTest {
         void 정회원만_참석_가능한_행사에_정회원이_아닌_유저가_신청하면_실패한다() {
             // given
             Member guestMember = fixtureHelper.createGuestMember(1L);
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.ENABLED, // 정회원 전용 신청 폼
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용 신청 폼
 
             // when & then
             assertThatThrownBy(() -> domainService.joinOnsiteForRegistered(guestMember, event))
@@ -204,12 +167,7 @@ public class EventParticipationDomainServiceTest {
         void 정회원만_참석_가능한_행사에_신청하면_실패한다() {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.ENABLED, // 정회원 전용 신청 폼
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용 신청 폼
 
             // when & then
             assertThatThrownBy(() -> domainService.joinOnsiteForUnregistered(participant, event, false))
@@ -226,12 +184,7 @@ public class EventParticipationDomainServiceTest {
         void 정회원만_참석_가능한_행사에_정회원이_아닌_유저가_신청하면_실패한다() {
             // given
             Member guestMember = fixtureHelper.createGuestMember(1L);
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.ENABLED, // 정회원 전용 신청 폼
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용 신청 폼
 
             // when & then
             assertThatThrownBy(() -> domainService.applyManualForRegistered(guestMember, event))
@@ -243,12 +196,7 @@ public class EventParticipationDomainServiceTest {
         void 뒤풀이가_있는_행사의_경우_뒤풀이_신청_상태가_APPLIED로_설정된다() {
             // given
             Member member = fixtureHelper.createRegularMember(1L);
-            Event eventWithAfterParty = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.ENABLED, // 뒤풀이 활성화
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event eventWithAfterParty = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
 
             // when
             EventParticipation participation = domainService.applyManualForRegistered(member, eventWithAfterParty);
@@ -262,12 +210,7 @@ public class EventParticipationDomainServiceTest {
         void 뒤풀이가_없는_행사의_경우_뒤풀이_신청_상태가_NONE으로_설정된다() {
             // given
             Member member = fixtureHelper.createRegularMember(1L);
-            Event eventWithoutAfterParty = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.DISABLED, // 뒤풀이 비활성화
-                    UsageStatus.DISABLED,
-                    UsageStatus.DISABLED);
+            Event eventWithoutAfterParty = fixtureHelper.createEventWithoutAfterParty(1L);
 
             // when
             EventParticipation participation = domainService.applyManualForRegistered(member, eventWithoutAfterParty);
@@ -281,8 +224,7 @@ public class EventParticipationDomainServiceTest {
         void 기본_정보가_작성되지_않은_회원이_신청하면_실패한다() {
             // given
             Member guestMember = fixtureHelper.createGuestMember(1L); // 기본 정보 미작성
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
 
             // when & then
             assertThatThrownBy(() -> domainService.applyManualForRegistered(guestMember, event))
@@ -299,12 +241,7 @@ public class EventParticipationDomainServiceTest {
         void 정회원만_참석_가능한_행사에_신청하면_실패한다() {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.ENABLED, // 정회원 전용 신청 폼
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용 신청 폼
 
             // when & then
             assertThatThrownBy(() -> domainService.applyManualForUnregistered(participant, event, false))
@@ -317,12 +254,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             // TODO: createAfterPartyDisabledEvent 사용하도록 개선
-            Event eventWithAfterParty = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.ENABLED, // 뒤풀이 활성화
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event eventWithAfterParty = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
 
             // when
             EventParticipation participation =
@@ -337,12 +269,7 @@ public class EventParticipationDomainServiceTest {
         void 뒤풀이가_없는_행사의_경우_뒤풀이_신청_상태가_NONE으로_설정된다() {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
-            Event eventWithoutAfterParty = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.DISABLED, // 뒤풀이 비활성화
-                    UsageStatus.DISABLED,
-                    UsageStatus.DISABLED);
+            Event eventWithoutAfterParty = fixtureHelper.createEventWithoutAfterParty(1L);
 
             // when
             EventParticipation participation =
@@ -357,8 +284,7 @@ public class EventParticipationDomainServiceTest {
         void 기본_정보가_작성된_학번으로_신청하면_실패한다() {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
 
             boolean infoStatusSatisfiedMemberExists = true; // 기본정보가 작성된 회원이 존재함
 
@@ -380,12 +306,7 @@ public class EventParticipationDomainServiceTest {
             Participant participant =
                     Participant.of(regularMember.getName(), regularMember.getStudentId(), regularMember.getPhone());
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.DISABLED, // 모두 참석 가능 (정회원 전용 비활성화)
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED); // 모두 참석 가능 (정회원 전용 비활성화)
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when
@@ -404,12 +325,7 @@ public class EventParticipationDomainServiceTest {
             Member guestMember = fixtureHelper.createGuestMember(1L);
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.DISABLED, // 모두 참석 가능 (정회원 전용 비활성화)
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED); // 모두 참석 가능 (정회원 전용 비활성화)
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when
@@ -426,12 +342,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.DISABLED, // 모두 참석 가능 (정회원 전용 비활성화)
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED); // 모두 참석 가능 (정회원 전용 비활성화)
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when
@@ -449,12 +360,7 @@ public class EventParticipationDomainServiceTest {
             Member guestMember = fixtureHelper.createGuestMember(1L);
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.ENABLED, // 정회원 전용
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -468,12 +374,7 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    UsageStatus.ENABLED, // 정회원 전용
-                    AFTER_PARTY_STATUS,
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -489,8 +390,7 @@ public class EventParticipationDomainServiceTest {
             Participant participant =
                     Participant.of(regularMember.getName(), regularMember.getStudentId(), regularMember.getPhone());
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
             LocalDateTime invalidDate = LocalDateTime.of(2025, 4, 1, 0, 0);
 
             // when & then
@@ -506,12 +406,7 @@ public class EventParticipationDomainServiceTest {
             Participant participant =
                     Participant.of(regularMember.getName(), regularMember.getStudentId(), regularMember.getPhone());
             AfterPartyApplicationStatus noneStatus = AfterPartyApplicationStatus.NONE;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.ENABLED, // 뒤풀이 활성화
-                    PRE_PAYMENT_STATUS,
-                    POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -527,12 +422,7 @@ public class EventParticipationDomainServiceTest {
             Participant participant =
                     Participant.of(regularMember.getName(), regularMember.getStudentId(), regularMember.getPhone());
             AfterPartyApplicationStatus appliedStatus = AfterPartyApplicationStatus.APPLIED;
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.DISABLED, // 뒤풀이 비활성화
-                    UsageStatus.DISABLED,
-                    UsageStatus.DISABLED);
+            Event event = fixtureHelper.createEventWithoutAfterParty(1L);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
 
             // when & then
@@ -549,8 +439,7 @@ public class EventParticipationDomainServiceTest {
         void 성공한다() {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
 
             // when
             EventParticipation participation = domainService.applyManual(participant, null, event);
@@ -566,12 +455,7 @@ public class EventParticipationDomainServiceTest {
         void 뒤풀이가_없는_행사의_경우_뒤풀이_신청_상태가_NONE으로_설정된다() {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
-            Event event = fixtureHelper.createEvent(
-                    1L,
-                    REGULAR_ROLE_ONLY_STATUS,
-                    UsageStatus.DISABLED, // 뒤풀이 비활성화
-                    UsageStatus.DISABLED,
-                    UsageStatus.DISABLED);
+            Event event = fixtureHelper.createEventWithoutAfterParty(1L);
 
             // when
             EventParticipation participation = domainService.applyManual(participant, null, event);
@@ -588,8 +472,7 @@ public class EventParticipationDomainServiceTest {
         void 성공한다() {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
-            Event event = fixtureHelper.createEvent(
-                    1L, REGULAR_ROLE_ONLY_STATUS, AFTER_PARTY_STATUS, PRE_PAYMENT_STATUS, POST_PAYMENT_STATUS);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
 
             // when
             EventParticipation participation = domainService.joinOnsite(participant, null, event);

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
@@ -4,7 +4,6 @@ import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
-import com.gdschongik.gdsc.global.exception.CustomException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -14,29 +13,30 @@ public class EventTest {
     class 행사_생성시 {
 
         @Test
-        void 뒤풀이가_없는_행사에_선입금_혹은_후정산이_활성화되면_실패한다() {
-            // given
-            UsageStatus afterPartyStatus = UsageStatus.DISABLED; // 뒤풀이 비활성화
-            UsageStatus prePaymentStatus = UsageStatus.ENABLED; // 선입금 활성화
-            UsageStatus postPaymentStatus = UsageStatus.ENABLED; // 후정산 활성화
+        void 뒤풀이활성상태가_ENABLED인_이벤트가_생성된다() {
+            // when
+            Event event = Event.create(
+                    EVENT_NAME,
+                    VENUE,
+                    EVENT_START_AT,
+                    EVENT_APPLICATION_PERIOD,
+                    REGULAR_ROLE_ONLY_STATUS,
+                    MAIN_EVENT_MAX_APPLICATION_COUNT,
+                    AFTER_PARTY_MAX_APPLICATION_COUNT);
 
-            // when & then
-            assertThatThrownBy(() -> Event.create(
-                            EVENT_NAME,
-                            VENUE,
-                            EVENT_START_AT,
-                            APPLICATION_DESCRIPTION,
-                            EVENT_APPLICATION_PERIOD,
-                            REGULAR_ROLE_ONLY_STATUS,
-                            afterPartyStatus,
-                            prePaymentStatus,
-                            postPaymentStatus,
-                            RSVP_QUESTION_STATUS,
-                            NOTICE_CONFIRM_QUESTION_STATUS,
-                            MAIN_EVENT_MAX_APPLICATION_COUNT,
-                            AFTER_PARTY_MAX_APPLICATION_COUNT))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(EVENT_NOT_CREATABLE_PAYMENT_ENABLED.getMessage());
+            // then
+            assertThat(event.getName()).isEqualTo(EVENT_NAME);
+            assertThat(event.getVenue()).isEqualTo(VENUE);
+            assertThat(event.getStartAt()).isEqualTo(EVENT_START_AT);
+            assertThat(event.getApplicationPeriod()).isEqualTo(EVENT_APPLICATION_PERIOD);
+            assertThat(event.getRegularRoleOnlyStatus()).isEqualTo(REGULAR_ROLE_ONLY_STATUS);
+            assertThat(event.getAfterPartyStatus()).isEqualTo(UsageStatus.ENABLED);
+            assertThat(event.getPrePaymentStatus()).isEqualTo(UsageStatus.DISABLED);
+            assertThat(event.getPostPaymentStatus()).isEqualTo(UsageStatus.DISABLED);
+            assertThat(event.getRsvpQuestionStatus()).isEqualTo(UsageStatus.DISABLED);
+            assertThat(event.getNoticeConfirmQuestionStatus()).isEqualTo(UsageStatus.DISABLED);
+            assertThat(event.getMainEventMaxApplicantCount()).isEqualTo(MAIN_EVENT_MAX_APPLICATION_COUNT);
+            assertThat(event.getAfterPartyMaxApplicantCount()).isEqualTo(AFTER_PARTY_MAX_APPLICATION_COUNT);
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/PaymentStatusTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/PaymentStatusTest.java
@@ -1,10 +1,10 @@
 package com.gdschongik.gdsc.domain.event.domain;
 
-import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gdschongik.gdsc.helper.FixtureHelper;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class PaymentStatusTest {
 
@@ -13,12 +13,7 @@ public class PaymentStatusTest {
     @Test
     void 선입금이_활성화된_이벤트일_경우_선입금_기본값은_NOT_PAID이다() {
         // given
-        Event event = fixtureHelper.createEvent(
-                1L,
-                UsageStatus.DISABLED,
-                UsageStatus.ENABLED, // 뒤풀이 활성화
-                UsageStatus.ENABLED, // 선입금 활성화
-                UsageStatus.DISABLED);
+        Event event = createEventWithPrePaymentEnabled();
 
         // when
         PaymentStatus status = PaymentStatus.getInitialPrePaymentStatus(event);
@@ -30,12 +25,7 @@ public class PaymentStatusTest {
     @Test
     void 선입금이_비활성화된_이벤트일_경우_선입금_기본값은_NONE이다() {
         // given
-        Event event = fixtureHelper.createEvent(
-                1L,
-                UsageStatus.DISABLED,
-                UsageStatus.ENABLED, // 뒤풀이 활성화
-                UsageStatus.DISABLED, // 선입금 비활성화
-                UsageStatus.DISABLED);
+        Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED);
 
         // when
         PaymentStatus status = PaymentStatus.getInitialPrePaymentStatus(event);
@@ -47,12 +37,7 @@ public class PaymentStatusTest {
     @Test
     void 후정산이_활성화된_이벤트일_경우_후정산_기본값은_NOT_PAID이다() {
         // given
-        Event event = fixtureHelper.createEvent(
-                1L,
-                UsageStatus.DISABLED,
-                UsageStatus.ENABLED, // 뒤풀이 활성화
-                UsageStatus.DISABLED,
-                UsageStatus.ENABLED); // 후정산 활성화
+        Event event = createEventWithPostPaymentEnabled();
 
         // when
         PaymentStatus status = PaymentStatus.getInitialPostPaymentStatus(event);
@@ -64,17 +49,24 @@ public class PaymentStatusTest {
     @Test
     void 후정산이_비활성화된_이벤트일_경우_후정산_기본값은_NONE이다() {
         // given
-        Event event = fixtureHelper.createEvent(
-                1L,
-                UsageStatus.DISABLED,
-                UsageStatus.ENABLED, // 뒤풀이 활성화
-                UsageStatus.DISABLED,
-                UsageStatus.DISABLED); // 후정산 비활성화
+        Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED);
 
         // when
         PaymentStatus status = PaymentStatus.getInitialPostPaymentStatus(event);
 
         // then
         assertThat(status).isEqualTo(PaymentStatus.NONE);
+    }
+
+    private Event createEventWithPrePaymentEnabled() {
+        Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED);
+        ReflectionTestUtils.setField(event, "prePaymentStatus", UsageStatus.ENABLED);
+        return event;
+    }
+
+    private Event createEventWithPostPaymentEnabled() {
+        Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED);
+        ReflectionTestUtils.setField(event, "postPaymentStatus", UsageStatus.ENABLED);
+        return event;
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/FixtureHelper.java
@@ -165,28 +165,32 @@ public class FixtureHelper {
         return study;
     }
 
-    public Event createEvent(
-            Long id,
-            UsageStatus regularRoleOnlyStatus,
-            UsageStatus afterPartyStatus,
-            UsageStatus prePaymentStatus,
-            UsageStatus postPaymentStatus) {
+    public Event createEventWithAfterParty(Long id, UsageStatus regularRoleOnlyStatus) {
         Event event = Event.create(
                 EVENT_NAME,
                 VENUE,
                 EVENT_START_AT,
-                APPLICATION_DESCRIPTION,
                 EVENT_APPLICATION_PERIOD,
                 regularRoleOnlyStatus,
-                afterPartyStatus,
-                prePaymentStatus,
-                postPaymentStatus,
-                RSVP_QUESTION_STATUS,
-                NOTICE_CONFIRM_QUESTION_STATUS,
                 MAIN_EVENT_MAX_APPLICATION_COUNT,
                 AFTER_PARTY_MAX_APPLICATION_COUNT);
 
         setId(event, id);
+        return event;
+    }
+
+    public Event createEventWithoutAfterParty(Long id) {
+        Event event = Event.create(
+                EVENT_NAME,
+                VENUE,
+                EVENT_START_AT,
+                EVENT_APPLICATION_PERIOD,
+                REGULAR_ROLE_ONLY_STATUS,
+                MAIN_EVENT_MAX_APPLICATION_COUNT,
+                AFTER_PARTY_MAX_APPLICATION_COUNT);
+
+        setId(event, id);
+        ReflectionTestUtils.setField(event, "afterPartyStatus", UsageStatus.DISABLED);
         return event;
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
+++ b/src/test/java/com/gdschongik/gdsc/helper/IntegrationTest.java
@@ -346,14 +346,8 @@ public abstract class IntegrationTest {
                 EVENT_NAME,
                 VENUE,
                 EVENT_START_AT,
-                APPLICATION_DESCRIPTION,
                 EVENT_APPLICATION_PERIOD,
                 REGULAR_ROLE_ONLY_STATUS,
-                AFTER_PARTY_STATUS,
-                PRE_PAYMENT_STATUS,
-                POST_PAYMENT_STATUS,
-                RSVP_QUESTION_STATUS,
-                NOTICE_CONFIRM_QUESTION_STATUS,
                 MAIN_EVENT_MAX_APPLICATION_COUNT,
                 AFTER_PARTY_MAX_APPLICATION_COUNT);
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1220

## 📌 작업 내용 및 특이사항
- 현재 Event.create 및 이를 사용하는 API의 요청 스키마를 변경
- 파라미터는 아래처럼 변경
  ```
  String name,
  String venue,
  LocalDateTime startAt,
  Period applicationPeriod,
  UsageStatus regularRoleOnlyStatus,
  Integer mainEventMaxApplicantCount,
  Integer afterPartyMaxApplicantCount
  ```
- 파라미터로 받지 않고, 내부에서 호출하는 빌더에서 지정하는 디폴트 값은 아래와 같음
  - afterPartyStatus: ENABLED -> 기본적으로 뒤풀이 활성상태로 생성됨
  - prePayment, postPayment, rsvp, notice: DISABLED
- validatePaymentDisabledWhenAfterPartyDisabled 및 관련 에러코드는 미사용하므로 제거
- EventTest 변경
  - 뒤풀이활성상태가 ENABLED인 테스트 케이스 추가
  - 나머지 활성상태는 모두 DISABLED인 테스트 케이스 추가 
- EventServiceTest 파라미터 맞춰주기

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 이벤트 생성 입력 항목을 간소화했습니다. 이름, 장소, 시작 일시, 신청 기간, 정회원 전용 여부, 본행사/뒤풀이 최대 인원만 입력하면 됩니다.
  - 생성 시 기본값이 자동 적용됩니다: 뒤풀이는 기본 활성화, 선입금/후정산/RSVP/공지 확인 질문은 기본 비활성화.
- Chores
  - 더 이상 발생하지 않는 관련 오류 코드를 제거했습니다.
- Tests
  - 변경된 이벤트 생성 흐름에 맞춰 테스트와 테스트 픽스처를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->