### PR TITLE
/1226 event basic info update

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
@@ -3,7 +3,7 @@ package com.gdschongik.gdsc.domain.event.api;
 import com.gdschongik.gdsc.domain.event.application.EventService;
 import com.gdschongik.gdsc.domain.event.dto.dto.EventDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
-import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateBasicInfoRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -45,11 +45,11 @@ public class AdminEventController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "이벤트 수정", description = "이벤트 기본 정보를 수정합니다.")
-    @PutMapping("/{eventId}")
-    public ResponseEntity<Void> updateEvent(
-            @PathVariable Long eventId, @Valid @RequestBody EventUpdateRequest request) {
-        eventService.updateEvent(eventId, request);
+    @Operation(summary = "이벤트 기본 정보 수정", description = "이벤트 기본 정보를 수정합니다.")
+    @PutMapping("/{eventId}/basic-info")
+    public ResponseEntity<Void> updateEventBasicInfo(
+            @PathVariable Long eventId, @Valid @RequestBody EventUpdateBasicInfoRequest request) {
+        eventService.updateEventBasicInfo(eventId, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -8,7 +8,7 @@ import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.domain.event.domain.service.EventDomainService;
 import com.gdschongik.gdsc.domain.event.dto.dto.EventDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
-import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateBasicInfoRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.util.List;
@@ -62,18 +62,18 @@ public class EventService {
     }
 
     @Transactional
-    public void updateEvent(Long eventId, EventUpdateRequest request) {
+    public void updateEventBasicInfo(Long eventId, EventUpdateBasicInfoRequest request) {
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
         long currentMainEventApplicantCount = eventParticipationRepository.countMainEventApplicantsByEvent(event);
         long currentAfterPartyApplicantCount = eventParticipationRepository.countAfterPartyApplicantsByEvent(event);
 
-        eventDomainService.update(
+        eventDomainService.updateBasicInfo(
                 event,
                 request.name(),
                 request.venue(),
                 request.startAt(),
-                request.applicationDescription(),
                 request.applicationPeriod(),
+                request.regularRoleOnlyStatus(),
                 request.mainEventMaxApplicantCount(),
                 request.afterPartyMaxApplicantCount(),
                 currentMainEventApplicantCount,
@@ -81,6 +81,6 @@ public class EventService {
 
         eventRepository.save(event);
 
-        log.info("[EventService] 이벤트 수정 완료: eventId={}", event.getId());
+        log.info("[EventService] 이벤트 기본 정보 수정 완료: eventId={}", event.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/Event.java
@@ -153,23 +153,23 @@ public class Event extends BaseEntity {
     // 수정 메서드
 
     /**
-     * 이벤트 정보를 수정합니다.
+     * 이벤트 기본 정보를 수정합니다.
      * 도메인 서비스를 통해서만 호출되어야 합니다.
      * @see EventDomainService
      */
-    public void update(
+    public void updateBasicInfo(
             String name,
             String venue,
             LocalDateTime startAt,
-            String applicationDescription,
             Period applicationPeriod,
+            UsageStatus regularRoleOnlyStatus,
             Integer mainEventMaxApplicantCount,
             Integer afterPartyMaxApplicantCount) {
         this.name = name;
         this.venue = venue;
         this.startAt = startAt;
-        this.applicationDescription = applicationDescription;
         this.applicationPeriod = applicationPeriod;
+        this.regularRoleOnlyStatus = regularRoleOnlyStatus;
         this.mainEventMaxApplicantCount = mainEventMaxApplicantCount;
         this.afterPartyMaxApplicantCount = afterPartyMaxApplicantCount;
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventUpdateBasicInfoRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventUpdateBasicInfoRequest.java
@@ -1,16 +1,17 @@
 package com.gdschongik.gdsc.domain.event.dto.request;
 
 import com.gdschongik.gdsc.domain.common.vo.Period;
+import com.gdschongik.gdsc.domain.event.domain.UsageStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 
-public record EventUpdateRequest(
+public record EventUpdateBasicInfoRequest(
         @NotBlank String name,
         String venue,
         @NotNull LocalDateTime startAt,
-        @NotBlank String applicationDescription,
         @NotNull Period applicationPeriod,
+        @NotNull UsageStatus regularRoleOnlyStatus,
         @Positive Integer mainEventMaxApplicantCount,
         @Positive Integer afterPartyMaxApplicantCount) {}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -201,6 +201,7 @@ public enum ErrorCode {
     EVENT_NOT_APPLICABLE_MEMBER_INFO_NOT_SATISFIED(CONFLICT, "기본 회원정보 작성이 완료되지 않은 회원은 이벤트에 신청할 수 없습니다."),
     EVENT_NOT_APPLICABLE_MEMBER_INFO_SATISFIED(CONFLICT, "기본 회원정보가 작성된 회원의 학번으로는 비회원 신청을 할 수 없습니다."),
     EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID(CONFLICT, "최대 신청자 수를 현재 신청자 수보다 적게 변경할 수 없습니다."),
+    EVENT_NOT_UPDATABLE_ALREADY_EXISTS_APPLICANT(CONFLICT, "이미 신청자가 존재하는 이벤트는 폼 관련 항목을 수정할 수 없습니다."),
     PARTICIPATION_NOT_FOUND(NOT_FOUND, "존재하지 않는 이벤트 참여정보입니다."),
     PARTICIPATION_NOT_READABLE_AFTER_PARTY_DISABLED(BAD_REQUEST, "뒤풀이가 비활성화된 이벤트의 참여정보는 조회할 수 없습니다."),
     PARTICIPATION_NOT_DELETABLE_INVALID_IDS(BAD_REQUEST, "존재하지 않거나 중복된 참여 정보 ID가 포함되어 있습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
-import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateBasicInfoRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import org.junit.jupiter.api.Nested;
@@ -45,17 +45,17 @@ public class EventServiceTest extends IntegrationTest {
         void 존재하지_않는_이벤트일_경우_실패한다() {
             // given
             String updatedName = "수정된 행사 이름";
-            var request = new EventUpdateRequest(
+            var request = new EventUpdateBasicInfoRequest(
                     updatedName,
                     VENUE,
                     EVENT_START_AT,
-                    APPLICATION_DESCRIPTION,
                     EVENT_APPLICATION_PERIOD,
+                    REGULAR_ROLE_ONLY_STATUS,
                     MAIN_EVENT_MAX_APPLICATION_COUNT,
                     AFTER_PARTY_MAX_APPLICATION_COUNT);
 
             // when & then
-            assertThatThrownBy(() -> eventService.updateEvent(1L, request))
+            assertThatThrownBy(() -> eventService.updateEventBasicInfo(1L, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_FOUND.getMessage());
         }
@@ -67,17 +67,17 @@ public class EventServiceTest extends IntegrationTest {
             Long eventId = event.getId();
 
             String updatedName = "수정된 행사 이름";
-            var request = new EventUpdateRequest(
+            var request = new EventUpdateBasicInfoRequest(
                     updatedName,
                     VENUE,
                     EVENT_START_AT,
-                    APPLICATION_DESCRIPTION,
                     EVENT_APPLICATION_PERIOD,
+                    REGULAR_ROLE_ONLY_STATUS,
                     MAIN_EVENT_MAX_APPLICATION_COUNT,
                     AFTER_PARTY_MAX_APPLICATION_COUNT);
 
             // when
-            eventService.updateEvent(eventId, request);
+            eventService.updateEventBasicInfo(eventId, request);
 
             // then
             assertThat(eventRepository.findById(eventId).get().getName()).isEqualTo(updatedName);

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
@@ -16,7 +16,33 @@ public class EventDomainServiceTest {
     FixtureHelper fixtureHelper = new FixtureHelper();
 
     @Nested
-    class 이벤트를_수정할_때 {
+    class 이벤트_기본정보를_수정할_때 {
+
+        @Test
+        void 신청자가_존재하는데_정회원_전용_이벤트_여부를_변경하면_실패한다() {
+            // given
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED); // 정회원 전용 X
+
+            UsageStatus newRegularRoleOnlyStatus = UsageStatus.ENABLED; // 정회원 전용 O
+            long currentMainEventApplicants = 10; // 이미 신청한 인원
+            long currentAfterPartyApplicants = 10;
+
+            // when & then
+            assertThatThrownBy(() -> eventDomainService.updateBasicInfo(
+                            event,
+                            EVENT_NAME,
+                            VENUE,
+                            EVENT_START_AT,
+                            EVENT_APPLICATION_PERIOD,
+                            newRegularRoleOnlyStatus,
+                            null,
+                            null,
+                            currentMainEventApplicants,
+                            currentAfterPartyApplicants))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(EVENT_NOT_UPDATABLE_ALREADY_EXISTS_APPLICANT.getMessage());
+        }
+
         @Test
         void 현재_신청인원보다_최대_신청인원을_많게_변경하는_경우_성공한다() {
             // given
@@ -28,13 +54,13 @@ public class EventDomainServiceTest {
             long currentAfterPartyApplicants = 10;
 
             // when
-            eventDomainService.update(
+            eventDomainService.updateBasicInfo(
                     event,
                     EVENT_NAME,
                     VENUE,
                     EVENT_START_AT,
-                    APPLICATION_DESCRIPTION,
                     EVENT_APPLICATION_PERIOD,
+                    REGULAR_ROLE_ONLY_STATUS,
                     newMainEventMaxApplicantCount,
                     newAfterPartyMaxApplicantCount,
                     currentMainEventApplicants,
@@ -55,13 +81,13 @@ public class EventDomainServiceTest {
             long currentAfterPartyApplicants = 10;
 
             // when
-            eventDomainService.update(
+            eventDomainService.updateBasicInfo(
                     event,
                     EVENT_NAME,
                     VENUE,
                     EVENT_START_AT,
-                    APPLICATION_DESCRIPTION,
                     EVENT_APPLICATION_PERIOD,
+                    REGULAR_ROLE_ONLY_STATUS,
                     newMainEventMaxApplicantCount,
                     newAfterPartyMaxApplicantCount,
                     currentMainEventApplicants,
@@ -82,13 +108,13 @@ public class EventDomainServiceTest {
             long currentAfterPartyApplicants = 10;
 
             // when & then
-            assertThatThrownBy(() -> eventDomainService.update(
+            assertThatThrownBy(() -> eventDomainService.updateBasicInfo(
                             event,
                             EVENT_NAME,
                             VENUE,
                             EVENT_START_AT,
-                            APPLICATION_DESCRIPTION,
                             EVENT_APPLICATION_PERIOD,
+                            REGULAR_ROLE_ONLY_STATUS,
                             newMainEventMaxApplicantCount,
                             newAfterPartyMaxApplicantCount,
                             currentMainEventApplicants,


### PR DESCRIPTION
## 🌱 관련 이슈
- {issue-close-placeholder-do-not-modify}

## 📌 작업 내용 및 특이사항
<img width="838" height="187" alt="스크린샷 2025-09-14 오후 4 32 57" src="https://github.com/user-attachments/assets/5bd494b9-a7bb-45a0-bc28-24cc3a588998" />

이벤트 생성, 수정 관련 로직 변경 (슬랙 참고)
- 기존 수정 API -> 기본 정보 수정으로 변경
- 행사 설명 항목 제거
- 정회원 전용 폼 여부 추가 (신청자 존재시 변경 불가능)


<img width="704" height="592" alt="스크린샷 2025-09-14 오후 4 35 12" src="https://github.com/user-attachments/assets/606be909-b35e-44f1-8963-5168c829e745" />

폼 관련 정보 수정 API는 다음 issue에서 추가 예정

## 📝 참고사항
-

## 📚 기타
-
