### PR TITLE
feat: 이벤트 신청 폼 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
@@ -4,6 +4,7 @@ import com.gdschongik.gdsc.domain.event.application.EventService;
 import com.gdschongik.gdsc.domain.event.dto.dto.EventDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateBasicInfoRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateFormInfoRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -50,6 +51,14 @@ public class AdminEventController {
     public ResponseEntity<Void> updateEventBasicInfo(
             @PathVariable Long eventId, @Valid @RequestBody EventUpdateBasicInfoRequest request) {
         eventService.updateEventBasicInfo(eventId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "이벤트 폼 정보 수정", description = "이벤트 신청 폼 관련 정보를 수정합니다.")
+    @PutMapping("/{eventId}/form-info")
+    public ResponseEntity<Void> updateEventFormInfo(
+            @PathVariable Long eventId, @Valid @RequestBody EventUpdateFormInfoRequest request) {
+        eventService.updateEventFormInfo(eventId, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -9,6 +9,7 @@ import com.gdschongik.gdsc.domain.event.domain.service.EventDomainService;
 import com.gdschongik.gdsc.domain.event.dto.dto.EventDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateBasicInfoRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateFormInfoRequest;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import java.util.List;
@@ -82,5 +83,25 @@ public class EventService {
         eventRepository.save(event);
 
         log.info("[EventService] 이벤트 기본 정보 수정 완료: eventId={}", event.getId());
+    }
+
+    @Transactional
+    public void updateEventFormInfo(Long eventId, EventUpdateFormInfoRequest request) {
+        Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
+        long currentMainEventApplicantCount = eventParticipationRepository.countMainEventApplicantsByEvent(event);
+
+        eventDomainService.updateFormInfo(
+                event,
+                request.applicationDescription(),
+                request.afterPartyStatus(),
+                request.prePaymentStatus(),
+                request.postPaymentStatus(),
+                request.rsvpQuestionStatus(),
+                request.noticeConfirmQuestionStatus(),
+                currentMainEventApplicantCount);
+
+        eventRepository.save(event);
+
+        log.info("[EventService] 이벤트 폼 정보 수정 완료: eventId={}", event.getId());
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -88,7 +88,7 @@ public class EventService {
     @Transactional
     public void updateEventFormInfo(Long eventId, EventUpdateFormInfoRequest request) {
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
-        long currentMainEventApplicantCount = eventParticipationRepository.countMainEventApplicantsByEvent(event);
+        boolean eventParticipationExists = eventParticipationRepository.existsByEvent(event);
 
         eventDomainService.updateFormInfo(
                 event,
@@ -98,7 +98,7 @@ public class EventService {
                 request.postPaymentStatus(),
                 request.rsvpQuestionStatus(),
                 request.noticeConfirmQuestionStatus(),
-                currentMainEventApplicantCount);
+                eventParticipationExists);
 
         eventRepository.save(event);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationRepository.java
@@ -12,4 +12,6 @@ public interface EventParticipationRepository
     List<EventParticipation> findAllByEvent(Event event);
 
     long countByEvent(Event event);
+
+    boolean existsByEvent(Event event);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
@@ -70,4 +70,29 @@ public class EventDomainService {
             throw new CustomException(EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID);
         }
     }
+
+    /**
+     * 이벤트 신청 폼 정보를 변경합니다.
+     * 이미 신청자가 존재하는 경우 수정할 수 없습니다.
+     * @param currentMainEventApplicantCount 현재 본 행사 신청자 수. EventParticipationRepository 조회 데이터
+     */
+    public void updateFormInfo(
+            Event event,
+            String applicationDescription,
+            UsageStatus afterPartyStatus,
+            UsageStatus prePaymentStatus,
+            UsageStatus postPaymentStatus,
+            UsageStatus rsvpQuestionStatus,
+            UsageStatus noticeConfirmQuestionStatus,
+            long currentMainEventApplicantCount) {
+        validateAlreadyExistsApplicant(currentMainEventApplicantCount);
+
+        event.updateFormInfo(
+                applicationDescription,
+                afterPartyStatus,
+                prePaymentStatus,
+                postPaymentStatus,
+                rsvpQuestionStatus,
+                noticeConfirmQuestionStatus);
+    }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventDomainService.java
@@ -74,7 +74,7 @@ public class EventDomainService {
     /**
      * 이벤트 신청 폼 정보를 변경합니다.
      * 이미 신청자가 존재하는 경우 수정할 수 없습니다.
-     * @param currentMainEventApplicantCount 현재 본 행사 신청자 수. EventParticipationRepository 조회 데이터
+     * @param eventParticipationExists 현재 본 행사 신청 정보가 존재하는지 유무. EventParticipationRepository 조회 데이터
      */
     public void updateFormInfo(
             Event event,
@@ -84,8 +84,8 @@ public class EventDomainService {
             UsageStatus postPaymentStatus,
             UsageStatus rsvpQuestionStatus,
             UsageStatus noticeConfirmQuestionStatus,
-            long currentMainEventApplicantCount) {
-        validateAlreadyExistsApplicant(currentMainEventApplicantCount);
+            boolean eventParticipationExists) {
+        validateAlreadyExistsEventParticipation(eventParticipationExists);
 
         event.updateFormInfo(
                 applicationDescription,
@@ -94,5 +94,14 @@ public class EventDomainService {
                 postPaymentStatus,
                 rsvpQuestionStatus,
                 noticeConfirmQuestionStatus);
+    }
+
+    /**
+     * 이미 신청자가 존재하는 경우 예외를 발생시킵니다.
+     */
+    private void validateAlreadyExistsEventParticipation(boolean eventParticipationExists) {
+        if (eventParticipationExists) {
+            throw new CustomException(EVENT_NOT_UPDATABLE_ALREADY_EXISTS_APPLICANT);
+        }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventUpdateFormInfoRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventUpdateFormInfoRequest.java
@@ -1,0 +1,13 @@
+package com.gdschongik.gdsc.domain.event.dto.request;
+
+import com.gdschongik.gdsc.domain.event.domain.UsageStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record EventUpdateFormInfoRequest(
+        @NotBlank String applicationDescription,
+        @NotNull UsageStatus afterPartyStatus,
+        @NotNull UsageStatus prePaymentStatus,
+        @NotNull UsageStatus postPaymentStatus,
+        @NotNull UsageStatus rsvpQuestionStatus,
+        @NotNull UsageStatus noticeConfirmQuestionStatus) {}

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -202,6 +202,7 @@ public enum ErrorCode {
     EVENT_NOT_APPLICABLE_MEMBER_INFO_SATISFIED(CONFLICT, "기본 회원정보가 작성된 회원의 학번으로는 비회원 신청을 할 수 없습니다."),
     EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID(CONFLICT, "최대 신청자 수를 현재 신청자 수보다 적게 변경할 수 없습니다."),
     EVENT_NOT_UPDATABLE_ALREADY_EXISTS_APPLICANT(CONFLICT, "이미 신청자가 존재하는 이벤트는 폼 관련 항목을 수정할 수 없습니다."),
+    EVENT_NOT_UPDATABLE_PAYMENT_STATUS_INVALID(CONFLICT, "뒤풀이가 비활성화된 이벤트는 결제 관련 항목을 활성화할 수 없습니다."),
     PARTICIPATION_NOT_FOUND(NOT_FOUND, "존재하지 않는 이벤트 참여정보입니다."),
     PARTICIPATION_NOT_READABLE_AFTER_PARTY_DISABLED(BAD_REQUEST, "뒤풀이가 비활성화된 이벤트의 참여정보는 조회할 수 없습니다."),
     PARTICIPATION_NOT_DELETABLE_INVALID_IDS(BAD_REQUEST, "존재하지 않거나 중복된 참여 정보 ID가 포함되어 있습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventServiceTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.gdschongik.gdsc.domain.event.domain.Event;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateBasicInfoRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateFormInfoRequest;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.helper.IntegrationTest;
 import org.junit.jupiter.api.Nested;
@@ -39,14 +40,14 @@ public class EventServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 이벤트_수정시 {
+    class 이벤트_기본_정보_수정시 {
 
         @Test
         void 존재하지_않는_이벤트일_경우_실패한다() {
             // given
-            String updatedName = "수정된 행사 이름";
+            Long invalidId = 999L;
             var request = new EventUpdateBasicInfoRequest(
-                    updatedName,
+                    EVENT_NAME,
                     VENUE,
                     EVENT_START_AT,
                     EVENT_APPLICATION_PERIOD,
@@ -55,7 +56,7 @@ public class EventServiceTest extends IntegrationTest {
                     AFTER_PARTY_MAX_APPLICATION_COUNT);
 
             // when & then
-            assertThatThrownBy(() -> eventService.updateEventBasicInfo(1L, request))
+            assertThatThrownBy(() -> eventService.updateEventBasicInfo(invalidId, request))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_FOUND.getMessage());
         }
@@ -81,6 +82,51 @@ public class EventServiceTest extends IntegrationTest {
 
             // then
             assertThat(eventRepository.findById(eventId).get().getName()).isEqualTo(updatedName);
+        }
+    }
+
+    @Nested
+    class 이벤트_폼_정보_수정시 {
+
+        @Test
+        void 존재하지_않는_이벤트일_경우_실패한다() {
+            // given
+            Long invalidId = 999L;
+            var request = new EventUpdateFormInfoRequest(
+                    APPLICATION_DESCRIPTION,
+                    AFTER_PARTY_STATUS,
+                    PRE_PAYMENT_STATUS,
+                    POST_PAYMENT_STATUS,
+                    RSVP_QUESTION_STATUS,
+                    NOTICE_CONFIRM_QUESTION_STATUS);
+
+            // when & then
+            assertThatThrownBy(() -> eventService.updateEventFormInfo(invalidId, request))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(EVENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 성공한다() {
+            // given
+            Event event = createEvent();
+            Long eventId = event.getId();
+
+            String updatedApplicationDescription = "수정된 행사 설명";
+            var request = new EventUpdateFormInfoRequest(
+                    updatedApplicationDescription,
+                    AFTER_PARTY_STATUS,
+                    PRE_PAYMENT_STATUS,
+                    POST_PAYMENT_STATUS,
+                    RSVP_QUESTION_STATUS,
+                    NOTICE_CONFIRM_QUESTION_STATUS);
+
+            // when
+            eventService.updateEventFormInfo(eventId, request);
+
+            // then
+            assertThat(eventRepository.findById(eventId).get().getApplicationDescription())
+                    .isEqualTo(updatedApplicationDescription);
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventDomainServiceTest.java
@@ -123,4 +123,28 @@ public class EventDomainServiceTest {
                     .hasMessage(EVENT_NOT_UPDATABLE_MAX_APPLICANT_COUNT_INVALID.getMessage());
         }
     }
+
+    @Nested
+    class 이벤트_폼_정보를_수정할_때 {
+
+        @Test
+        void 신청자가_존재하는데_수정을_시도하면_실패한다() {
+            // given
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED);
+            boolean eventParticipationExists = true; // 이미 신청자가 존재
+
+            // when & then
+            assertThatThrownBy(() -> eventDomainService.updateFormInfo(
+                            event,
+                            APPLICATION_DESCRIPTION,
+                            AFTER_PARTY_STATUS,
+                            PRE_PAYMENT_STATUS,
+                            POST_PAYMENT_STATUS,
+                            RSVP_QUESTION_STATUS,
+                            NOTICE_CONFIRM_QUESTION_STATUS,
+                            eventParticipationExists))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(EVENT_NOT_UPDATABLE_ALREADY_EXISTS_APPLICANT.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventTest.java
@@ -1,13 +1,19 @@
 package com.gdschongik.gdsc.domain.event.domain;
 
+import static com.gdschongik.gdsc.domain.event.domain.UsageStatus.DISABLED;
+import static com.gdschongik.gdsc.domain.event.domain.UsageStatus.ENABLED;
 import static com.gdschongik.gdsc.global.common.constant.EventConstant.*;
 import static com.gdschongik.gdsc.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
+import com.gdschongik.gdsc.global.exception.CustomException;
+import com.gdschongik.gdsc.helper.FixtureHelper;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class EventTest {
+
+    private FixtureHelper fixtureHelper = new FixtureHelper();
 
     @Nested
     class 행사_생성시 {
@@ -30,13 +36,54 @@ public class EventTest {
             assertThat(event.getStartAt()).isEqualTo(EVENT_START_AT);
             assertThat(event.getApplicationPeriod()).isEqualTo(EVENT_APPLICATION_PERIOD);
             assertThat(event.getRegularRoleOnlyStatus()).isEqualTo(REGULAR_ROLE_ONLY_STATUS);
-            assertThat(event.getAfterPartyStatus()).isEqualTo(UsageStatus.ENABLED);
-            assertThat(event.getPrePaymentStatus()).isEqualTo(UsageStatus.DISABLED);
-            assertThat(event.getPostPaymentStatus()).isEqualTo(UsageStatus.DISABLED);
-            assertThat(event.getRsvpQuestionStatus()).isEqualTo(UsageStatus.DISABLED);
-            assertThat(event.getNoticeConfirmQuestionStatus()).isEqualTo(UsageStatus.DISABLED);
+            assertThat(event.getAfterPartyStatus()).isEqualTo(ENABLED);
+            assertThat(event.getPrePaymentStatus()).isEqualTo(DISABLED);
+            assertThat(event.getPostPaymentStatus()).isEqualTo(DISABLED);
+            assertThat(event.getRsvpQuestionStatus()).isEqualTo(DISABLED);
+            assertThat(event.getNoticeConfirmQuestionStatus()).isEqualTo(DISABLED);
             assertThat(event.getMainEventMaxApplicantCount()).isEqualTo(MAIN_EVENT_MAX_APPLICATION_COUNT);
             assertThat(event.getAfterPartyMaxApplicantCount()).isEqualTo(AFTER_PARTY_MAX_APPLICATION_COUNT);
+        }
+    }
+
+    @Nested
+    class 폼_정보_수정시 {
+
+        @Test
+        void 뒤풀이가_비활성화인데_결제_관련_상태가_활성화되면_실패한다() {
+            // given
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
+
+            // when & then
+            assertThatThrownBy(() -> event.updateFormInfo(
+                            APPLICATION_DESCRIPTION,
+                            DISABLED, // 뒤풀이 비활성화
+                            ENABLED, // 사전 결제 활성화
+                            ENABLED,
+                            RSVP_QUESTION_STATUS,
+                            NOTICE_CONFIRM_QUESTION_STATUS))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(EVENT_NOT_UPDATABLE_PAYMENT_STATUS_INVALID.getMessage());
+        }
+
+        @Test
+        void 뒤풀이가_비활성화되면_뒤풀이_인원제한이_초기화된다() {
+            // given
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
+            assertThat(event.getAfterPartyMaxApplicantCount()).isEqualTo(AFTER_PARTY_MAX_APPLICATION_COUNT);
+
+            // when
+            event.updateFormInfo(
+                    APPLICATION_DESCRIPTION,
+                    DISABLED, // 뒤풀이 비활성화
+                    DISABLED,
+                    DISABLED,
+                    RSVP_QUESTION_STATUS,
+                    NOTICE_CONFIRM_QUESTION_STATUS);
+
+            // then
+            assertThat(event.getAfterPartyStatus()).isEqualTo(DISABLED);
+            assertThat(event.getAfterPartyMaxApplicantCount()).isNull();
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1227
- close #1221

## 📌 작업 내용 및 특이사항
- 폼 정보 관련 수정 로직을 구현했습니다.
- 뒤풀이가 비활성화되는 경우 뒤풀이 인원제한 필드를 초기화합니다 (#1221)

- 결제 상태도 뒤풀이가 비활성화되면 초기화해야 하는거 아닌가요?
-> 그럼 사용자 입력을 보고 뒤풀이 상태가 활성화이면 사용, 비활성화이면 결제 상태를 무시하고 초기화하거나 Nullable하게 구현해야하는데,
 그럼 전체 수정이 아니라 상황에 맞게 수정이니까 Http Method를 Patch으로 써야 하고..
 Nullable이면 활성화상태일땐 null 검사도 해야하고..
 그래서 그냥 사용자 입력으로 결제 상태도 항상 받고, 정합성에 어긋나면 예외 던지도록 했습니다. 



## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 관리자에서 이벤트 폼 설정(신청 안내, 뒤풀이 사용 여부, 선/후결제 여부, RSVP 및 공지 확인)을 수정할 수 있습니다.
- 개선
  - 이미 신청자가 있는 이벤트는 폼 정보 수정을 제한합니다.
  - 뒤풀이를 비활성화하면 결제 관련 항목을 활성화할 수 없고, 뒤풀이 인원 제한이 초기화됩니다.
  - 관련 오류 상황에 대해 명확한 충돌 오류 메시지를 제공합니다.
- Tests
  - 폼 정보 수정의 성공/실패(존재하지 않는 이벤트, 제약 위반 등) 시나리오 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->