### PR TITLE
feat: 행사 참여 가능 멤버 검색 API에 전화번호 필드 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/dto/EventParticipableMemberDto.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/dto/EventParticipableMemberDto.java
@@ -2,8 +2,10 @@ package com.gdschongik.gdsc.domain.event.dto.dto;
 
 import com.gdschongik.gdsc.domain.member.domain.Member;
 
-public record EventParticipableMemberDto(Long memberId, String name, String studentId, boolean participable) {
+public record EventParticipableMemberDto(
+        Long memberId, String name, String studentId, String phone, boolean participable) {
     public static EventParticipableMemberDto from(Member member, boolean participable) {
-        return new EventParticipableMemberDto(member.getId(), member.getName(), member.getStudentId(), participable);
+        return new EventParticipableMemberDto(
+                member.getId(), member.getName(), member.getStudentId(), member.getPhone(), participable);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1232

## 📌 작업 내용 및 특이사항
- 어드민 수동 신청시 Participant의 이름, 학번, 전번을 입력해야 하는데, 회원의 경우 이 3가지가 검색을 통해 자동입력 되는 플로우라서 전화번호도 추가해줘야 합니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 이벤트 참여 가능 회원 정보에 전화번호가 추가되어 목록과 상세에서 확인할 수 있습니다.
  * 관리자/운영자는 참가자 검토, 초대, 공지 발송 시 연락처를 바로 확인해 작업이 간소화됩니다.
  * 내보내기나 외부 연동 시에도 전화번호가 함께 전달되어 후속 처리 효율이 향상됩니다.
  * 기존 화면 흐름은 유지되며, 최신 클라이언트에서 추가 정보가 자연스럽게 노출됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->