### PR TITLE
refactor: 에러코드 네이밍 형식 통일

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/NicknameModifyHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/discord/application/handler/NicknameModifyHandler.java
@@ -34,7 +34,7 @@ public class NicknameModifyHandler implements DiscordEventHandler {
         }
 
         if (newNickname == null) {
-            throw new CustomException(ErrorCode.DISCORD_NICKNAME_NOTNULL);
+            throw new CustomException(ErrorCode.DISCORD_NICKNAME_NOT_NULL);
         }
 
         if (newNickname.equals(originalNickname)) {

--- a/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRound.java
@@ -76,7 +76,7 @@ public class RecruitmentRound extends BaseEntity {
 
     public void validatePeriodNotStarted(LocalDateTime now) {
         if (now.isAfter(period.getStartDate())) {
-            throw new CustomException(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED);
+            throw new CustomException(RECRUITMENT_ROUND_START_DATE_ALREADY_PASSED);
         }
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistory.java
@@ -103,7 +103,7 @@ public class AssignmentHistory extends BaseEntity {
 
     public void fail(SubmissionFailureType submissionFailureType) {
         if (submissionFailureType == NOT_SUBMITTED || submissionFailureType == NONE) {
-            throw new CustomException(ASSIGNMENT_INVALID_FAILURE_TYPE);
+            throw new CustomException(ASSIGNMENT_FAILURE_TYPE_INVALID);
         }
 
         this.submissionLink = null;

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryV2.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/domain/AssignmentHistoryV2.java
@@ -106,7 +106,7 @@ public class AssignmentHistoryV2 {
 
     public void fail(SubmissionFailureType submissionFailureType) {
         if (submissionFailureType == NOT_SUBMITTED || submissionFailureType == NONE) {
-            throw new CustomException(ASSIGNMENT_INVALID_FAILURE_TYPE);
+            throw new CustomException(ASSIGNMENT_FAILURE_TYPE_INVALID);
         }
         this.submissionLink = null;
         this.commitHash = null;

--- a/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/NotionWebhookRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/studyv2/dto/request/NotionWebhookRequest.java
@@ -22,7 +22,7 @@ public record NotionWebhookRequest(Source source, Data data) {
         switch (rawSemesterType) {
             case "1" -> semesterType = SemesterType.FIRST;
             case "2" -> semesterType = SemesterType.SECOND;
-            default -> throw new CustomException(ErrorCode.METHOD_ARGUMENT_NOT_VALID);
+            default -> throw new CustomException(ErrorCode.METHOD_ARGUMENT_INVALID);
         }
 
         return Semester.of(academicYear, semesterType);

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     INTERNAL_ERROR(INTERNAL_SERVER_ERROR, "내부 서버 에러가 발생했습니다. 관리자에게 문의 바랍니다."),
-    METHOD_ARGUMENT_NULL(BAD_REQUEST, "인자는 null이 될 수 없습니다."),
-    METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, "인자가 유효하지 않습니다."),
+    METHOD_ARGUMENT_NOT_NULL(BAD_REQUEST, "인자는 null이 될 수 없습니다."),
+    METHOD_ARGUMENT_INVALID(BAD_REQUEST, "인자가 유효하지 않습니다."),
     REGEX_VIOLATION(BAD_REQUEST, "정규표현식을 위반했습니다."),
     FORBIDDEN_ACCESS(FORBIDDEN, "접근 권한이 없습니다."),
     SORT_NOT_SUPPORTED(BAD_REQUEST, "지원되지 않는 정렬 기준입니다."),
@@ -68,7 +68,7 @@ public enum ErrorCode {
     DISCORD_CODE_MISMATCH(CONFLICT, "디스코드 인증코드가 일치하지 않습니다."),
     DISCORD_ROLE_NOT_FOUND(NOT_FOUND, "디스코드 역할을 찾을 수 없습니다."),
     DISCORD_NOT_SIGNUP(INTERNAL_SERVER_ERROR, "아직 가입신청서를 작성하지 않은 회원입니다."),
-    DISCORD_NICKNAME_NOTNULL(INTERNAL_SERVER_ERROR, "닉네임은 빈 값이 될 수 없습니다."),
+    DISCORD_NICKNAME_NOT_NULL(INTERNAL_SERVER_ERROR, "닉네임은 빈 값이 될 수 없습니다."),
     DISCORD_MEMBER_NOT_FOUND(NOT_FOUND, "디스코드 멤버를 찾을 수 없습니다."),
     DISCORD_CHANNEL_NOT_FOUND(NOT_FOUND, "디스코드 채널을 찾을 수 없습니다."),
 
@@ -90,7 +90,7 @@ public enum ErrorCode {
     // RecruitmentRound
     RECRUITMENT_ROUND_NOT_FOUND(NOT_FOUND, "모집회차가 존재하지 않습니다."),
     RECRUITMENT_ROUND_TYPE_OVERLAP(BAD_REQUEST, "모집 차수가 중복됩니다."),
-    RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED(BAD_REQUEST, "이미 모집 시작일이 지난 모집회차입니다."),
+    RECRUITMENT_ROUND_START_DATE_ALREADY_PASSED(BAD_REQUEST, "이미 모집 시작일이 지난 모집회차입니다."),
     ROUND_ONE_DOES_NOT_EXIST(CONFLICT, "1차 모집이 존재하지 않습니다."),
 
     // Coupon
@@ -171,7 +171,7 @@ public enum ErrorCode {
     ORDER_FINAL_PAYMENT_AMOUNT_MISMATCH(CONFLICT, "주문 최종결제금액은 주문총액에서 할인금액을 뺀 값이어야 합니다."),
 
     // Assignment
-    ASSIGNMENT_INVALID_FAILURE_TYPE(CONFLICT, "유효하지 않은 제출 실패사유입니다."),
+    ASSIGNMENT_FAILURE_TYPE_INVALID(CONFLICT, "유효하지 않은 제출 실패사유입니다."),
     ASSIGNMENT_DEADLINE_INVALID(CONFLICT, "과제 마감 기한이 현재보다 빠릅니다."),
     ASSIGNMENT_STUDY_NOT_APPLIED(CONFLICT, "해당 스터디에 대한 수강신청 기록이 존재하지 않습니다."),
     ASSIGNMENT_SUBMIT_NOT_STARTED(CONFLICT, "아직 과제가 시작되지 않았습니다."),

--- a/src/main/java/com/gdschongik/gdsc/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/GlobalExceptionHandler.java
@@ -40,6 +40,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.info("METHOD_ARGUMENT_NOT_VALID : {}", e.getMessage());
         String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         return ResponseEntity.status(status.value())
-                .body(ErrorResponse.of(ErrorCode.METHOD_ARGUMENT_NOT_VALID, errorMessage));
+                .body(ErrorResponse.of(ErrorCode.METHOD_ARGUMENT_INVALID, errorMessage));
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/member/domain/MemberValidatorTest.java
@@ -34,7 +34,7 @@ public class MemberValidatorTest {
             // when & then
             assertThatThrownBy(() -> memberValidator.validateMemberDemote(recruitmentRounds, now))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED.getMessage());
+                    .hasMessage(RECRUITMENT_ROUND_START_DATE_ALREADY_PASSED.getMessage());
         }
 
         @Test

--- a/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/recruitment/domain/RecruitmentRoundValidatorTest.java
@@ -217,7 +217,7 @@ public class RecruitmentRoundValidatorTest {
             assertThatThrownBy(() -> recruitmentRoundValidator.validateRecruitmentRoundUpdate(
                             START_DATE, END_DATE, LocalDateTime.now(), ROUND_TYPE, recruitmentRound, List.of()))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(RECRUITMENT_ROUND_STARTDATE_ALREADY_PASSED.getMessage());
+                    .hasMessage(RECRUITMENT_ROUND_START_DATE_ALREADY_PASSED.getMessage());
         }
     }
 }

--- a/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/study/domain/AssignmentHistoryTest.java
@@ -123,7 +123,7 @@ class AssignmentHistoryTest {
             // when, then
             assertThatThrownBy(() -> assignmentHistory.fail(SubmissionFailureType.NOT_SUBMITTED))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(ASSIGNMENT_INVALID_FAILURE_TYPE.getMessage());
+                    .hasMessageContaining(ASSIGNMENT_FAILURE_TYPE_INVALID.getMessage());
         }
 
         @Test
@@ -138,7 +138,7 @@ class AssignmentHistoryTest {
             // when, then
             assertThatThrownBy(() -> assignmentHistory.fail(SubmissionFailureType.NONE))
                     .isInstanceOf(CustomException.class)
-                    .hasMessageContaining(ASSIGNMENT_INVALID_FAILURE_TYPE.getMessage());
+                    .hasMessageContaining(ASSIGNMENT_FAILURE_TYPE_INVALID.getMessage());
         }
 
         @Test


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1095

## 📌 작업 내용 및 특이사항
- `NULL` 관련 에러 코드 네이밍 `NOT_NULL` 사용하도록 수정
- `NOT_VALID` -> `INVALID` 표현 통일

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 해당 없음

- 버그 수정
  - 닉네임 미입력 시 일관된 오류 응답 반환.
  - 모집 라운드 시작일이 지난 경우의 오류 응답 정합성 개선.
  - 과제 실패 유형이 유효하지 않을 때의 오류 응답 정정.
  - 잘못된 요청 매개변수에 대한 검증 오류 응답 맵핑 보완.

- 리팩터링
  - 전역 오류 코드 명명 규칙을 표준화하여 응답 일관성 향상(동작 및 메시지 변경 없음).

- 테스트
  - 변경된 오류 응답에 맞추어 단위 테스트 기대값 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->