### PR TITLE
test: 이벤트 참여 신청 정책 변경에 따른 테스트 수정

### DIFF
--- a/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/application/EventParticipationServiceTest.java
@@ -1105,18 +1105,21 @@ class EventParticipationServiceTest extends IntegrationTest {
     }
 
     private EventParticipation createEventParticipation(Event event, Member member) {
-        EventParticipation eventParticipation = EventParticipation.createOnlineForRegistered(
+        EventParticipation eventParticipation = EventParticipation.createOnline(
+                Participant.of(member.getName(), member.getStudentId(), member.getPhone()),
                 member,
                 AfterPartyApplicationStatus.NOT_APPLIED,
                 AfterPartyAttendanceStatus.NOT_ATTENDED,
                 PaymentStatus.NONE,
                 PaymentStatus.NONE,
                 event);
+
         return eventParticipationRepository.save(eventParticipation);
     }
 
     private EventParticipation createAfterPartyParticipation(Event event, Member member) {
-        EventParticipation eventParticipation = EventParticipation.createOnlineForRegistered(
+        EventParticipation eventParticipation = EventParticipation.createOnline(
+                Participant.of(member.getName(), member.getStudentId(), member.getPhone()),
                 member,
                 AfterPartyApplicationStatus.APPLIED,
                 AfterPartyAttendanceStatus.NOT_ATTENDED,
@@ -1127,7 +1130,8 @@ class EventParticipationServiceTest extends IntegrationTest {
     }
 
     private EventParticipation createAfterPartyDisabledEventParticipation(Event event, Member member) {
-        EventParticipation eventParticipation = EventParticipation.createOnlineForRegistered(
+        EventParticipation eventParticipation = EventParticipation.createOnline(
+                Participant.of(member.getName(), member.getStudentId(), member.getPhone()),
                 member,
                 AfterPartyApplicationStatus.NONE,
                 AfterPartyAttendanceStatus.NONE,
@@ -1138,7 +1142,8 @@ class EventParticipationServiceTest extends IntegrationTest {
     }
 
     private EventParticipation createUnconfirmedAfterPartyEventParticipation(Event event, Member member) {
-        EventParticipation eventParticipation = EventParticipation.createOnlineForRegistered(
+        EventParticipation eventParticipation = EventParticipation.createOnline(
+                Participant.of(member.getName(), member.getStudentId(), member.getPhone()),
                 member,
                 AfterPartyApplicationStatus.APPLIED,
                 AfterPartyAttendanceStatus.NOT_ATTENDED,
@@ -1149,7 +1154,8 @@ class EventParticipationServiceTest extends IntegrationTest {
     }
 
     private EventParticipation createConfirmedAfterPartyEventParticipation(Event event, Member member) {
-        EventParticipation eventParticipation = EventParticipation.createOnlineForRegistered(
+        EventParticipation eventParticipation = EventParticipation.createOnline(
+                Participant.of(member.getName(), member.getStudentId(), member.getPhone()),
                 member,
                 AfterPartyApplicationStatus.APPLIED,
                 AfterPartyAttendanceStatus.ATTENDED,
@@ -1160,8 +1166,9 @@ class EventParticipationServiceTest extends IntegrationTest {
     }
 
     private EventParticipation createUnregisteredEventParticipation(Event event, Participant participant) {
-        EventParticipation eventParticipation = EventParticipation.createOnlineForUnregistered(
+        EventParticipation eventParticipation = EventParticipation.createOnline(
                 participant,
+                null,
                 AfterPartyApplicationStatus.NOT_APPLIED,
                 AfterPartyAttendanceStatus.NOT_ATTENDED,
                 PaymentStatus.NONE,

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/ParticipantRoleTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/ParticipantRoleTest.java
@@ -110,22 +110,13 @@ class ParticipantRoleTest {
     }
 
     private EventParticipation createEventParticipation(Member member) {
-        if (member != null) {
-            return EventParticipation.createOnlineForRegistered(
-                    member,
-                    AfterPartyApplicationStatus.NOT_APPLIED,
-                    AfterPartyAttendanceStatus.NOT_ATTENDED,
-                    PaymentStatus.UNPAID,
-                    PaymentStatus.UNPAID,
-                    null);
-        } else {
-            return EventParticipation.createOnlineForUnregistered(
-                    Participant.of(NAME, STUDENT_ID, PHONE_NUMBER),
-                    AfterPartyApplicationStatus.NOT_APPLIED,
-                    AfterPartyAttendanceStatus.NOT_ATTENDED,
-                    PaymentStatus.UNPAID,
-                    PaymentStatus.UNPAID,
-                    null);
-        }
+        return EventParticipation.createOnline(
+                Participant.of(NAME, STUDENT_ID, PHONE_NUMBER),
+                member,
+                AfterPartyApplicationStatus.NOT_APPLIED,
+                AfterPartyAttendanceStatus.NOT_ATTENDED,
+                PaymentStatus.UNPAID,
+                PaymentStatus.UNPAID,
+                null);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1235

## 📌 작업 내용 및 특이사항
- test 돌릴 때마다 deprecated 메서드들 때문에 warning 뜨길래 제거했습니다.
- 여전히 warning 뜨는 테스트가 있는데, test class 자체가 deprecated되거나 정책 변경에 의해 무의미해진 테스트들은 곧 삭제할 것 같아서 굳이 수정하지 않았습니다.
## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 온라인 이벤트 참여 생성 과정을 단일 흐름으로 통합하여 일관성과 유지보수성을 개선했습니다.
  - 중복 로직을 제거해 구조를 간소화하고 향후 변경에 대한 안정성을 높였습니다.
- Tests
  - 테스트 케이스와 테스트 헬퍼를 새로운 생성 흐름에 맞게 정비해 가독성을 높이고 중복을 줄였습니다.
  - 등록/미등록 시나리오를 공통 패턴으로 검증하도록 업데이트했습니다.
  
사용자 기능상의 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->