### PR TITLE
feat: 이벤트 참여신청시 중복 신청 검증 추가

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
@@ -313,12 +313,19 @@ public class EventParticipationService {
         Event event =
                 eventRepository.findById(request.eventId()).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
 
+        boolean isEventParticipationDuplicate = eventParticipationRepository.existsByEventAndParticipantStudentId(
+                event, request.participant().getStudentId());
         Participant participant = request.participant();
         Member memberByParticipant =
                 memberRepository.findByStudentId(participant.getStudentId()).orElse(null);
 
         EventParticipation eventParticipation = eventParticipationDomainService.applyOnline(
-                participant, memberByParticipant, request.afterPartyApplicationStatus(), event, now());
+                participant,
+                memberByParticipant,
+                request.afterPartyApplicationStatus(),
+                event,
+                now(),
+                isEventParticipationDuplicate);
 
         eventParticipationRepository.save(eventParticipation);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
@@ -240,12 +240,14 @@ public class EventParticipationService {
         Event event =
                 eventRepository.findById(request.eventId()).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
 
+        boolean isEventParticipationDuplicate = eventParticipationRepository.existsByEventAndParticipantStudentId(
+                event, request.participant().getStudentId());
         Participant participant = request.participant();
         Member memberByParticipant =
                 memberRepository.findByStudentId(participant.getStudentId()).orElse(null);
 
-        EventParticipation participation =
-                eventParticipationDomainService.applyManual(participant, memberByParticipant, event);
+        EventParticipation participation = eventParticipationDomainService.applyManual(
+                participant, memberByParticipant, event, isEventParticipationDuplicate);
         eventParticipationRepository.save(participation);
 
         log.info(

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationRepository.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dao/EventParticipationRepository.java
@@ -14,4 +14,6 @@ public interface EventParticipationRepository
     long countByEvent(Event event);
 
     boolean existsByEvent(Event event);
+
+    boolean existsByEventAndParticipantStudentId(Event event, String studentId);
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
@@ -174,7 +174,9 @@ public class EventParticipationDomainService {
      * 주로 본행사 현장등록 상황에서 뒤풀이 신청을 위해 사용됩니다. (뒤풀이 신청상태 APPLIED)
      * 뒤풀이가 없는 행사인 경우에도 히스토리를 남기기 위해 사용됩니다. (뒤풀이 신청상태 NONE)
      */
-    public EventParticipation applyManual(Participant participant, @Nullable Member member, Event event) {
+    public EventParticipation applyManual(
+            Participant participant, @Nullable Member member, Event event, boolean isEventParticipationDuplicate) {
+        validateEventParticipationDuplicate(isEventParticipationDuplicate);
         // 뒤풀이가 존재하는 경우에만 항상 신청 처리
         AfterPartyApplicationStatus afterPartyApplicationStatus = event.afterPartyExists() ? APPLIED : NONE;
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
@@ -148,7 +148,9 @@ public class EventParticipationDomainService {
             @Nullable Member member,
             AfterPartyApplicationStatus afterPartyApplicationStatus,
             Event event,
-            LocalDateTime now) {
+            LocalDateTime now,
+            boolean isEventParticipationDuplicate) {
+        validateEventParticipationDuplicate(isEventParticipationDuplicate);
         validateEventApplicationPeriod(event, now);
         validateMemberWhenOnlyRegularRoleAllowedIfExists(event, member); // applyOnline에서만 수행
         validateAfterPartyApplicationStatus(event, afterPartyApplicationStatus);
@@ -285,6 +287,15 @@ public class EventParticipationDomainService {
 
         if (member == null || !member.isRegular()) {
             throw new CustomException(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE);
+        }
+    }
+
+    /**
+     * 이벤트 중복 신청 여부를 검증합니다.
+     */
+    private void validateEventParticipationDuplicate(boolean isEventParticipationDuplicate) {
+        if (isEventParticipationDuplicate) {
+            throw new CustomException(PARTICIPATION_DUPLICATE);
         }
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
+++ b/src/main/java/com/gdschongik/gdsc/global/exception/ErrorCode.java
@@ -215,6 +215,7 @@ public enum ErrorCode {
     PARTICIPANT_ROLE_NOT_CREATABLE_BOTH_EXISTENCE_MISMATCH(
             INTERNAL_SERVER_ERROR, "이벤트 참여정보의 멤버 ID와 멤버 인자는 둘 다 null이거나 not null이어야 합니다."),
     PARTICIPANT_ROLE_NOT_CREATABLE_BOTH_ID_MISMATCH(INTERNAL_SERVER_ERROR, "이벤트 참여정보의 멤버 ID와 인자의 멤버 ID가 일치하지 않습니다."),
+    PARTICIPATION_DUPLICATE(CONFLICT, "이미 해당 이벤트를 신청했습니다."),
     AFTER_PARTY_NOT_ATTENDABLE_DISABLED(CONFLICT, "뒤풀이가 비활성화 된 경우, 뒤풀이에 참석할 수 없습니다."),
     AFTER_PARTY_NOT_ATTENDABLE_ALREADY_ATTENDED(CONFLICT, "이미 뒤풀이에 참석하였습니다."),
     AFTER_PARTY_ATTENDANCE_STATUS_NOT_REVOKABLE_DISABLED(CONFLICT, "뒤풀이가 비활성화 된 경우, 뒤풀이 참석을 취소할 수 없습니다."),

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -308,10 +308,11 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED); // 모두 참석 가능 (정회원 전용 비활성화)
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
+            boolean isEventParticipationDuplicate = false;
 
             // when
-            EventParticipation participation =
-                    domainService.applyOnline(participant, regularMember, status, event, now);
+            EventParticipation participation = domainService.applyOnline(
+                    participant, regularMember, status, event, now, isEventParticipationDuplicate);
 
             // then
             assertThat(participation.getMemberId()).isEqualTo(regularMember.getId());
@@ -327,9 +328,11 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED); // 모두 참석 가능 (정회원 전용 비활성화)
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
+            boolean isEventParticipationDuplicate = false;
 
             // when
-            EventParticipation participation = domainService.applyOnline(participant, guestMember, status, event, now);
+            EventParticipation participation = domainService.applyOnline(
+                    participant, guestMember, status, event, now, isEventParticipationDuplicate);
 
             // then
             assertThat(participation.getMemberId()).isEqualTo(guestMember.getId());
@@ -344,9 +347,11 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED); // 모두 참석 가능 (정회원 전용 비활성화)
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
+            boolean isEventParticipationDuplicate = false;
 
             // when
-            EventParticipation participation = domainService.applyOnline(participant, null, status, event, now);
+            EventParticipation participation =
+                    domainService.applyOnline(participant, null, status, event, now, isEventParticipationDuplicate);
 
             // then
             assertThat(participation.getMemberId()).isNull();
@@ -362,9 +367,11 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
+            boolean isEventParticipationDuplicate = false;
 
             // when & then
-            assertThatThrownBy(() -> domainService.applyOnline(participant, guestMember, status, event, now))
+            assertThatThrownBy(() -> domainService.applyOnline(
+                            participant, guestMember, status, event, now, isEventParticipationDuplicate))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE.getMessage());
         }
@@ -376,9 +383,11 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.ENABLED); // 정회원 전용
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
+            boolean isEventParticipationDuplicate = false;
 
             // when & then
-            assertThatThrownBy(() -> domainService.applyOnline(participant, null, status, event, now))
+            assertThatThrownBy(() -> domainService.applyOnline(
+                            participant, null, status, event, now, isEventParticipationDuplicate))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_NOT_REGULAR_ROLE.getMessage());
         }
@@ -392,9 +401,11 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
             Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
             LocalDateTime invalidDate = LocalDateTime.of(2025, 4, 1, 0, 0);
+            boolean isEventParticipationDuplicate = false;
 
             // when & then
-            assertThatThrownBy(() -> domainService.applyOnline(participant, regularMember, status, event, invalidDate))
+            assertThatThrownBy(() -> domainService.applyOnline(
+                            participant, regularMember, status, event, invalidDate, isEventParticipationDuplicate))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_APPLICATION_PERIOD_INVALID.getMessage());
         }
@@ -408,9 +419,11 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus noneStatus = AfterPartyApplicationStatus.NONE;
             Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
+            boolean isEventParticipationDuplicate = false;
 
             // when & then
-            assertThatThrownBy(() -> domainService.applyOnline(participant, regularMember, noneStatus, event, now))
+            assertThatThrownBy(() -> domainService.applyOnline(
+                            participant, regularMember, noneStatus, event, now, isEventParticipationDuplicate))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_AFTER_PARTY_NONE.getMessage());
         }
@@ -424,11 +437,31 @@ public class EventParticipationDomainServiceTest {
             AfterPartyApplicationStatus appliedStatus = AfterPartyApplicationStatus.APPLIED;
             Event event = fixtureHelper.createEventWithoutAfterParty(1L);
             LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
+            boolean isEventParticipationDuplicate = false;
 
             // when & then
-            assertThatThrownBy(() -> domainService.applyOnline(participant, regularMember, appliedStatus, event, now))
+            assertThatThrownBy(() -> domainService.applyOnline(
+                            participant, regularMember, appliedStatus, event, now, isEventParticipationDuplicate))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(EVENT_NOT_APPLICABLE_AFTER_PARTY_DISABLED.getMessage());
+        }
+
+        @Test
+        void 이미_신청한_이벤트를_다시_신청하면_실패한다() {
+            // given
+            Member regularMember = fixtureHelper.createRegularMember(1L);
+            Participant participant =
+                    Participant.of(regularMember.getName(), regularMember.getStudentId(), regularMember.getPhone());
+            AfterPartyApplicationStatus status = AfterPartyApplicationStatus.APPLIED;
+            Event event = fixtureHelper.createEventWithAfterParty(1L, UsageStatus.DISABLED); // 모두 참석 가능 (정회원 전용 비활성화)
+            LocalDateTime now = LocalDateTime.of(2025, 3, 1, 0, 0);
+            boolean isEventParticipationDuplicate = true;
+
+            // when & then
+            assertThatThrownBy(() -> domainService.applyOnline(
+                            participant, regularMember, status, event, now, isEventParticipationDuplicate))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(PARTICIPATION_DUPLICATE.getMessage());
         }
     }
 

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -473,9 +473,11 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
+            boolean isEventParticipationDuplicate = false;
 
             // when
-            EventParticipation participation = domainService.applyManual(participant, null, event);
+            EventParticipation participation =
+                    domainService.applyManual(participant, null, event, isEventParticipationDuplicate);
 
             // then
             assertThat(participation.getMemberId()).isNull();
@@ -489,12 +491,27 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             Event event = fixtureHelper.createEventWithoutAfterParty(1L);
+            boolean isEventParticipationDuplicate = false;
 
             // when
-            EventParticipation participation = domainService.applyManual(participant, null, event);
+            EventParticipation participation =
+                    domainService.applyManual(participant, null, event, isEventParticipationDuplicate);
 
             // then
             assertThat(participation.getAfterPartyApplicationStatus()).isEqualTo(AfterPartyApplicationStatus.NONE);
+        }
+
+        @Test
+        void 이미_신청한_이벤트를_다시_신청하면_실패한다() {
+            // given
+            Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
+            boolean isEventParticipationDuplicate = true;
+
+            // when & then
+            assertThatThrownBy(() -> domainService.applyManual(participant, null, event, isEventParticipationDuplicate))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(PARTICIPATION_DUPLICATE.getMessage());
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1240

## 📌 작업 내용 및 특이사항
- 온라인 신청과 수동 신청 과정에서 이미 신청한 경우 중복 신청 불가하다는 error message를 내려달라는 프론트 요청에 따라 검증 추가했습닙다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 이벤트 신청 시 중복 감지 추가: 동일 이벤트에 이미 신청한 사용자는 온라인/수동 모두 재신청 불가.
  - 중복 시 신청이 거절되며 HTTP 409와 “이미 해당 이벤트를 신청했습니다.” 메시지로 즉시 안내.
  - 중복 여부 선확인으로 불필요한 입력과 대기 시간 감소, 빠른 피드백 제공.
- **테스트**
  - 중복 시나리오에 대한 단위 테스트가 추가되어 동작이 검증됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->