### PR TITLE
feat: 이벤트 뒤풀이 현장등록 API 구현

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventParticipationController.java
@@ -6,6 +6,7 @@ import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyAttendRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyStatusUpdateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyStatusesUpdateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventManualApplyRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventOnsiteJoinRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipationDeleteRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventRegisteredManualApplyRequest;
@@ -148,6 +149,15 @@ public class AdminEventParticipationController {
     @PostMapping("/apply/manual")
     public ResponseEntity<Void> applyManual(@Valid @RequestBody EventManualApplyRequest request) {
         eventParticipationService.applyManual(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "뒤풀이 현장 신청",
+            description = "관리자가 참여자의 정보를 바탕으로 뒤풀이를 현장에서 수동으로 신청 처리합니다. 뒤풀이 신청 상태가 참석으로 처리됩니다.")
+    @PostMapping("/join/onsite")
+    public ResponseEntity<Void> joinOnsite(@Valid @RequestBody EventOnsiteJoinRequest request) {
+        eventParticipationService.joinOnsite(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventParticipationService.java
@@ -17,6 +17,7 @@ import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyStatusesUpdateRequ
 import com.gdschongik.gdsc.domain.event.dto.request.AfterPartyUpdateTarget;
 import com.gdschongik.gdsc.domain.event.dto.request.EventApplyOnlineRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventManualApplyRequest;
+import com.gdschongik.gdsc.domain.event.dto.request.EventOnsiteJoinRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipantQueryOption;
 import com.gdschongik.gdsc.domain.event.dto.request.EventParticipationDeleteRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventRegisteredManualApplyRequest;
@@ -333,6 +334,28 @@ public class EventParticipationService {
 
         log.info(
                 "[EventParticipationService] 이벤트 참여 신청: eventId={}, memberStudentId={}",
+                event.getId(),
+                participant.getStudentId());
+    }
+
+    @Transactional
+    public void joinOnsite(EventOnsiteJoinRequest request) {
+        Event event =
+                eventRepository.findById(request.eventId()).orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
+
+        boolean isEventParticipationDuplicate = eventParticipationRepository.existsByEventAndParticipantStudentId(
+                event, request.participant().getStudentId());
+        Participant participant = request.participant();
+        Member memberByParticipant =
+                memberRepository.findByStudentId(participant.getStudentId()).orElse(null);
+
+        EventParticipation eventParticipation = eventParticipationDomainService.joinOnsite(
+                participant, memberByParticipant, event, isEventParticipationDuplicate);
+
+        eventParticipationRepository.save(eventParticipation);
+
+        log.info(
+                "[EventParticipationService] 뒤풀이 현장등록: eventId={}, memberStudentId={}",
                 event.getId(),
                 participant.getStudentId());
     }

--- a/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/domain/service/EventParticipationDomainService.java
@@ -197,7 +197,9 @@ public class EventParticipationDomainService {
     /**
      * 뒤풀이 현장등록을 통해 뒤풀이에 확정 참여하는 메서드입니다.
      */
-    public EventParticipation joinOnsite(Participant participant, @Nullable Member member, Event event) {
+    public EventParticipation joinOnsite(
+            Participant participant, @Nullable Member member, Event event, boolean isEventParticipationDuplicate) {
+        validateEventParticipationDuplicate(isEventParticipationDuplicate);
         PaymentStatus prePaymentStatus = PaymentStatus.getInitialPrePaymentStatus(event);
         PaymentStatus postPaymentStatus = PaymentStatus.getInitialPostPaymentStatus(event);
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventOnsiteJoinRequest.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/request/EventOnsiteJoinRequest.java
@@ -1,0 +1,7 @@
+package com.gdschongik.gdsc.domain.event.dto.request;
+
+import com.gdschongik.gdsc.domain.event.domain.Participant;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record EventOnsiteJoinRequest(@NotNull @Positive Long eventId, @NotNull Participant participant) {}

--- a/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
+++ b/src/test/java/com/gdschongik/gdsc/domain/event/domain/EventParticipationDomainServiceTest.java
@@ -523,9 +523,11 @@ public class EventParticipationDomainServiceTest {
             // given
             Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
             Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
+            boolean isEventParticipationDuplicate = false;
 
             // when
-            EventParticipation participation = domainService.joinOnsite(participant, null, event);
+            EventParticipation participation =
+                    domainService.joinOnsite(participant, null, event, isEventParticipationDuplicate);
 
             // then
             assertThat(participation.getMemberId()).isNull();
@@ -534,6 +536,19 @@ public class EventParticipationDomainServiceTest {
             assertThat(participation.getAfterPartyApplicationStatus())
                     .isEqualTo(AfterPartyApplicationStatus.NOT_APPLIED);
             assertThat(participation.getAfterPartyAttendanceStatus()).isEqualTo(AfterPartyAttendanceStatus.ATTENDED);
+        }
+
+        @Test
+        void 이미_신청한_이벤트를_다시_신청하면_실패한다() {
+            // given
+            Participant participant = Participant.of(NAME, STUDENT_ID, PHONE_NUMBER);
+            Event event = fixtureHelper.createEventWithAfterParty(1L, REGULAR_ROLE_ONLY_STATUS);
+            boolean isEventParticipationDuplicate = true;
+
+            // when & then
+            assertThatThrownBy(() -> domainService.joinOnsite(participant, null, event, isEventParticipationDuplicate))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(PARTICIPATION_DUPLICATE.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1242

## 📌 작업 내용 및 특이사항
- dto의 경우 `EventManualApplyRequest`를 재활용 해도 되지만 이름이 너무 길어질 것 같아 분리했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 관리자용 현장 참가 처리 엔드포인트 추가(POST /admin/event-participations/join/onsite). 요청 시 이벤트 ID와 참가자 정보 검증, 성공 시 200 OK 응답.
- 버그 수정
  - 중복 참가 방지 검증을 도입해 이미 등록된 참가자의 현장 참가 처리를 차단.
- 테스트
  - 중복 참가 시 예외가 발생하는지 검증하는 테스트 추가 및 관련 호출부 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->