### PR TITLE
feat: 이벤트 생성 시 id 응답

### DIFF
--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
@@ -5,6 +5,7 @@ import com.gdschongik.gdsc.domain.event.dto.dto.EventDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateBasicInfoRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateFormInfoRequest;
+import com.gdschongik.gdsc.domain.event.dto.response.EventCreateResponse;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,8 +35,8 @@ public class AdminEventController {
 
     @Operation(summary = "행사 생성", description = "행사를 생성합니다.")
     @PostMapping
-    public ResponseEntity<Void> createEvent(@Valid @RequestBody EventCreateRequest request) {
-        eventService.createEvent(request);
+    public ResponseEntity<EventCreateResponse> createEvent(@Valid @RequestBody EventCreateRequest request) {
+        var response = eventService.createEvent(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/api/AdminEventController.java
@@ -37,7 +37,7 @@ public class AdminEventController {
     @PostMapping
     public ResponseEntity<EventCreateResponse> createEvent(@Valid @RequestBody EventCreateRequest request) {
         var response = eventService.createEvent(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "이벤트 검색", description = "이벤트를 검색합니다.")

--- a/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/application/EventService.java
@@ -10,6 +10,7 @@ import com.gdschongik.gdsc.domain.event.dto.dto.EventDto;
 import com.gdschongik.gdsc.domain.event.dto.request.EventCreateRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateBasicInfoRequest;
 import com.gdschongik.gdsc.domain.event.dto.request.EventUpdateFormInfoRequest;
+import com.gdschongik.gdsc.domain.event.dto.response.EventCreateResponse;
 import com.gdschongik.gdsc.domain.event.dto.response.EventResponse;
 import com.gdschongik.gdsc.global.exception.CustomException;
 import com.gdschongik.gdsc.global.lock.DistributedLock;
@@ -43,7 +44,7 @@ public class EventService {
     }
 
     @Transactional
-    public void createEvent(EventCreateRequest request) {
+    public EventCreateResponse createEvent(EventCreateRequest request) {
         Event event = Event.create(
                 request.name(),
                 request.venue(),
@@ -55,6 +56,7 @@ public class EventService {
         eventRepository.save(event);
 
         log.info("[EventService] 이벤트 생성: eventId={}", event.getId());
+        return EventCreateResponse.of(event.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gdschongik/gdsc/domain/event/dto/response/EventCreateResponse.java
+++ b/src/main/java/com/gdschongik/gdsc/domain/event/dto/response/EventCreateResponse.java
@@ -1,0 +1,8 @@
+package com.gdschongik.gdsc.domain.event.dto.response;
+
+public record EventCreateResponse(Long eventId) {
+
+    public static EventCreateResponse of(Long eventId) {
+        return new EventCreateResponse(eventId);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1250

## 📌 작업 내용 및 특이사항
- 프론트엔드 요청으로 이벤트 생성 API 응답에 id 를 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 이벤트 생성 시 생성된 이벤트의 식별자(eventId)를 응답으로 반환하도록 추가했습니다.
- 리팩터링
  - 이벤트 생성 흐름을 정비해 생성 결과를 응답으로 전달할 수 있게 구조를 개선했습니다.
- 기타
  - 외부에서 생성 결과(eventId)를 받아 후속 처리에 활용할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->